### PR TITLE
Remove OldParser infrastructure and complete migration to swift-parsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,19 +57,10 @@ The project uses swift-parsing library with custom operators:
 - Modify code generation: Update relevant files in `libcggen/`
 
 ### Migration Notes
-Currently migrating to swift-parsing library. Key changes:
-- Replace `Parser<D, T>` with concrete parser types
-- Update operators to return concrete types instead of existentials
-- Use `Parse`, `OneOf`, `Many` builders instead of custom implementations
-
-#### Removing .oldParser Usage
-When eliminating `.oldParser` usage, follow these patterns:
-- **Validation logic**: Convert `.oldParser.flatMapResult` to `.compactMap` with nil return for failures
-- **Dictionary parsing**: Use `DicitionaryKey` struct directly instead of `key()` wrapper + `.oldParser`
-- **Error handling**: Replace `Result { try parser.parse() }` with `try? parser.parse()` for optional results
-- **Parser wrapping**: Use `OldParser(newParser)` when function must return `OldParser` type
-- **One change at a time**: Make incremental changes and test each modification individually
-- **Avoid complex conversions**: Skip enum case handling and pullback operations until simpler patterns are complete
+Migration to swift-parsing library completed. Key changes made:
+- Replaced custom `zip` functions with `Parse` builder syntax
+- Removed legacy `OldParser` bridge infrastructure
+- Use `Parse`, `OneOf`, `Many` builders for parser composition
 
 ## Test Framework Migration (Swift Testing)
 
@@ -110,19 +101,16 @@ extension NewParser where Input == Substring, Output: Equatable {
 - Swift Testing requires `import Foundation` for `sqrt` and similar math functions
 - Use `Issue.record()` instead of `XCTFail()` for recording test failures
 
-## Legacy Code Removal
+## Parser Migration Completed
 
-### .oldParser Extension Elimination
-The codebase is gradually removing usage of the `.oldParser` extension that bridges NewParser to OldParser types. Progress tracking:
+The migration from legacy parser infrastructure to swift-parsing is now complete:
 
-**Completed removals**:
-- `version` parser in SVGParsing.swift (validation logic)
-- Both `attributeParser` functions in SVGParsing.swift (dictionary parsing)
+**Completed work**:
+- Replaced all `zip` function calls with `Parse` builder syntax
+- Removed `OldParser` struct and bridge infrastructure
+- Eliminated `.oldParser` extension usage throughout codebase
+- Updated test files to use direct Parser types
 
-**Remaining areas** (as of latest update):
-- Complex enum case handling in `element` functions
-- Pullback operations with XML parsing
-- Child parser compositions in `elementWithChildren`
-
-**Infrastructure added**:
-- `DicitionaryKey<Key, Value>: NewParser` - Direct dictionary key extraction without legacy wrappers
+**Key infrastructure**:
+- `DicitionaryKey<Key, Value>: Parser` - Direct dictionary key extraction
+- Custom parser operators (`~>>`, `<<~`, `~`, `*`, `+`, `~?`) for parsing DSL

--- a/Package.swift
+++ b/Package.swift
@@ -57,7 +57,7 @@ let package = Package(
       name: "UnitTests",
       dependencies: ["Base", "libcggen"],
       resources: [
-        .copy("UnitTests.xctestplan")
+        .copy("UnitTests.xctestplan"),
       ]
     ),
     .testTarget(
@@ -65,10 +65,10 @@ let package = Package(
       dependencies: ["libcggen", "BCRunner"],
       resources: [
         .copy("pdf_samples"),
-        .copy("svg_samples"), 
+        .copy("svg_samples"),
         .copy("various_filenames"),
         .copy("tests.sketch"),
-        .copy("RegressionSuite.xctestplan")
+        .copy("RegressionSuite.xctestplan"),
       ]
     ),
   ]

--- a/Sources/Base/SVGParsing.swift
+++ b/Sources/Base/SVGParsing.swift
@@ -608,12 +608,12 @@ public enum SVGParser {
     Attributes: Equatable, Child: Equatable
   >(
     attributes: AttributeGroupParser<Attributes>,
-    child: some Base.NewParser<XML, Child>
+    child: some Parser<XML, Child>
   ) -> some Parser<XML, SVG.ElementWithChildren<Attributes, Child>> {
     let childParser = First<ArraySlice<XML>>().compactMap { element in
       try? child.parse(element)
     }
-    let childrenParser: some NewParser<[XML], [Child]> =
+    let childrenParser: some Parser<[XML], [Child]> =
       (childParser* <<~ End())
         .pullback(\.slice)
     let attrs = (attributes <<~ End())
@@ -626,8 +626,8 @@ public enum SVGParser {
   private static func element<Attributes>(
     tag: Tag,
     attributes: AttributeGroupParser<Attributes>
-  ) -> some NewParser<XML, Attributes> {
-    let tag: some NewParser<XML.Element, Void> =
+  ) -> some Parser<XML, Attributes> {
+    let tag: some Parser<XML.Element, Void> =
       tag.rawValue
         .pullback(\.substring)
         .pullback(\XML.Element.tag)
@@ -682,13 +682,13 @@ public enum SVGParser {
     attributeParser(SVG.FilterPrimitiveFeColorMatrix.Kind.parser(), attribute)
   }
 
-  typealias FilterPrimitiveParser<T: Equatable> = NewParser<
+  typealias FilterPrimitiveParser<T: Equatable> = Parser<
     XML, SVG.FilterPrimitiveElement<T>
   >
 
   private static func elementTagFeBlend<Attributes>(
     _ attributes: AttributeGroupParser<Attributes>
-  ) -> some NewParser<XML, Attributes> {
+  ) -> some Parser<XML, Attributes> {
     element(tag: .feBlend, attributes: attributes)
   }
 
@@ -703,7 +703,7 @@ public enum SVGParser {
 
   private static func elementTagFeColorMatrix<Attributes>(
     _ attributes: AttributeGroupParser<Attributes>
-  ) -> some NewParser<XML, Attributes> {
+  ) -> some Parser<XML, Attributes> {
     element(tag: .feColorMatrix, attributes: attributes)
   }
 
@@ -718,7 +718,7 @@ public enum SVGParser {
 
   private static func elementTagFeFlood<Attributes>(
     _ attributes: AttributeGroupParser<Attributes>
-  ) -> some NewParser<XML, Attributes> {
+  ) -> some Parser<XML, Attributes> {
     element(tag: .feFlood, attributes: attributes)
   }
 
@@ -732,7 +732,7 @@ public enum SVGParser {
 
   private static func elementTagFeGaussianBlur<Attributes>(
     _ attributes: AttributeGroupParser<Attributes>
-  ) -> some NewParser<XML, Attributes> {
+  ) -> some Parser<XML, Attributes> {
     element(tag: .feGaussianBlur, attributes: attributes)
   }
 
@@ -746,7 +746,7 @@ public enum SVGParser {
 
   private static func elementTagFeOffset<Attributes>(
     _ attributes: AttributeGroupParser<Attributes>
-  ) -> some NewParser<XML, Attributes> {
+  ) -> some Parser<XML, Attributes> {
     element(tag: .feOffset, attributes: attributes)
   }
 
@@ -760,7 +760,7 @@ public enum SVGParser {
   }.eraseToAnyParser() |> filterPrimitive >>> elementTagFeOffset
 
   private nonisolated(unsafe)
-  static let filterPrimitiveContent: some NewParser<
+  static let filterPrimitiveContent: some Parser<
     XML, SVG.FilterPrimitiveContent
   > = OneOf {
     AnyParser(feBlend).map(SVG.FilterPrimitiveContent.feBlend)
@@ -770,7 +770,7 @@ public enum SVGParser {
     AnyParser(feOffset).map(SVG.FilterPrimitiveContent.feOffset)
   }
 
-  private nonisolated(unsafe) static let filter: some NewParser<
+  private nonisolated(unsafe) static let filter: some Parser<
     XML, SVG.Filter
   > = elementWithChildren(
     attributes: filterAttributes, child: filterPrimitiveContent

--- a/Sources/Base/SVGParsing.swift
+++ b/Sources/Base/SVGParsing.swift
@@ -255,12 +255,16 @@ public enum SVGParser {
     attributeParser(Rest())
   private nonisolated(unsafe)
   static let ignore: AttributeGroupParser<Void> =
-    DicitionaryKey<String, String>(Attribute.maskType.rawValue).map { _ in () }.eraseToAnyParser()
+    DicitionaryKey<String, String>(Attribute.maskType.rawValue).map { _ in () }
+      .eraseToAnyParser()
 
   private static let dashArray: ParserForAttribute<[SVG.Length]> =
     attributeParser(SVGAttributeParsers.dashArray)
 
-  private static let presentation: AttributeGroupParser<SVG.PresentationAttributes> = Parse(SVG.PresentationAttributes.init) {
+  private static let presentation: AttributeGroupParser<
+    SVG
+      .PresentationAttributes
+  > = Parse(SVG.PresentationAttributes.init) {
     funciri(.clipPath)
     fillRule(.clipRule)
     funciri(.mask)
@@ -453,18 +457,19 @@ public enum SVGParser {
   public static func linearGradient(
     from el: XML.Element
   ) throws -> SVG.LinearGradient {
-    let attrs = try (Parse { core, presentation, units, x1, y1, x2, y2, transform in
-      (core, presentation, units, x1, y1, x2, y2, transform)
-    } with: {
-      core
-      presentation
-      units(.gradientUnits)
-      coord(.x1)
-      coord(.y1)
-      coord(.x2)
-      coord(.y2)
-      transform(.gradientTransform)
-    } <<~ End()).run(el.attrs).get()
+    let attrs =
+      try (Parse { core, presentation, units, x1, y1, x2, y2, transform in
+        (core, presentation, units, x1, y1, x2, y2, transform)
+      } with: {
+        core
+        presentation
+        units(.gradientUnits)
+        coord(.x1)
+        coord(.y1)
+        coord(.x2)
+        coord(.y2)
+        transform(.gradientTransform)
+      } <<~ End()).run(el.attrs).get()
     let subelements: [XML.Element] = try el.children.map {
       switch $0 {
       case let .el(el):
@@ -489,19 +494,20 @@ public enum SVGParser {
   public static func radialGradient(
     from el: XML.Element
   ) throws -> SVG.RadialGradient {
-    let attrs = try (Parse { core, presentation, units, cx, cy, r, fx, fy, transform in
-      (core, presentation, units, cx, cy, r, fx, fy, transform)
-    } with: {
-      core
-      presentation
-      units(.gradientUnits)
-      coord(.cx)
-      coord(.cy)
-      len(.r)
-      coord(.fx)
-      coord(.fy)
-      transform(.gradientTransform)
-    } <<~ End()).run(el.attrs).get()
+    let attrs =
+      try (Parse { core, presentation, units, cx, cy, r, fx, fy, transform in
+        (core, presentation, units, cx, cy, r, fx, fy, transform)
+      } with: {
+        core
+        presentation
+        units(.gradientUnits)
+        coord(.cx)
+        coord(.cy)
+        len(.r)
+        coord(.fx)
+        coord(.fy)
+        transform(.gradientTransform)
+      } <<~ End()).run(el.attrs).get()
     let subelements: [XML.Element] = try el.children.map {
       switch $0 {
       case let .el(el):
@@ -548,19 +554,32 @@ public enum SVGParser {
   }
 
   public static func mask(from el: XML.Element) throws -> SVG.Mask {
-    let attrs = try (Parse { core, presentation, transform, x, y, width, height, maskUnits, maskContentUnits in
-      (core, presentation, transform, x, y, width, height, maskUnits, maskContentUnits)
-    } with: {
-      core
-      presentation
-      transform(.transform)
-      x
-      y
-      width
-      height
-      units(.maskUnits)
-      units(.maskContentUnits)
-    } <<~ ignore <<~ End()).run(el.attrs).get()
+    let attrs =
+      try (
+        Parse { core, presentation, transform, x, y, width, height, maskUnits, maskContentUnits in
+          (
+            core,
+            presentation,
+            transform,
+            x,
+            y,
+            width,
+            height,
+            maskUnits,
+            maskContentUnits
+          )
+        } with: {
+          core
+          presentation
+          transform(.transform)
+          x
+          y
+          width
+          height
+          units(.maskUnits)
+          units(.maskContentUnits)
+        } <<~ ignore <<~ End()
+      ).run(el.attrs).get()
     return try .init(
       core: attrs.0,
       presentation: attrs.1,
@@ -594,7 +613,10 @@ public enum SVGParser {
   }
 
   private nonisolated(unsafe) static
-  let filterAttributes: AttributeGroupParser<SVG.FilterAttributes> = Parse(SVG.FilterAttributes.init) {
+  let filterAttributes: AttributeGroupParser<SVG.FilterAttributes> = Parse(
+    SVG
+      .FilterAttributes.init
+  ) {
     core
     presentation
     x
@@ -670,12 +692,13 @@ public enum SVGParser {
   ) -> AttributeParser<SVG.FilterPrimitiveIn> {
     attributeParser(SVGAttributeParsers.filterPrimitiveIn, attribute)
   }
-  
+
   private static func blendMode(
     _ attribute: Attribute
   ) -> AttributeParser<SVG.BlendMode> {
     attributeParser(SVGAttributeParsers.blendMode, attribute)
   }
+
   private static func feColorMatrixType(
     _ attribute: Attribute
   ) -> AttributeParser<SVG.FilterPrimitiveFeColorMatrix.Kind> {

--- a/Tests/UnitTests/ParserTests.swift
+++ b/Tests/UnitTests/ParserTests.swift
@@ -61,7 +61,8 @@ import Parsing
     p.test("15_", expected: ("_16_", "_"))
   }
 
-  // Note: testZip removed since zip function is deprecated and replaced with Parse builders
+  // Note: testZip removed since zip function is deprecated and replaced with
+  // Parse builders
 
   @Test func testZeroOrMore() {
     let p: some Parser<[Int]> = (int <<~ "_")*


### PR DESCRIPTION
## Summary
- Remove OldParser struct and all its methods (45 lines of legacy code)
- Remove unused extension methods: `.oldParser`, `.identity()`, `.unwrap()`
- Update test file to use direct Parser types instead of OldParser
- Update CLAUDE.md to reflect completed parser migration

## Test plan
- [x] All existing tests pass with OldParser infrastructure removed
- [x] Build succeeds without any compilation errors
- [x] Parser functionality remains identical, only legacy bridge code removed

This completes the parser migration by eliminating the bridge between old and new parser types.

🤖 Generated with [Claude Code](https://claude.ai/code)