### PR TITLE
Fix whitespace parser crash in Swift internals

### DIFF
--- a/Sources/SVGParse/SVGAttributeParsers.swift
+++ b/Sources/SVGParse/SVGAttributeParsers.swift
@@ -3,12 +3,11 @@ import Base
 
 public enum SVGAttributeParsers {
   static let comma: String = ","
-  static let wsp = OneOf {
-    " "
-    "\t"
-    "\r"
-    "\n"
-  }
+  static let wsp = From(.utf8) { OneOf {
+    for s in [0x20, 0x9, 0xD, 0xA] as [UInt8] {
+      String.UTF8View([s])
+    }
+  }}
 
   // (wsp+ comma? wsp*) | (comma wsp*)
   static let commaWsp =


### PR DESCRIPTION
## Summary
- Reverts the whitespace parser implementation that was causing signal 10 crashes
- The character literal approach was triggering crashes in Swift internals (demangle/metadata)
- Returns to the UTF8 byte array approach which is stable

## Test plan
- [x] Run `swift test` - all tests pass without crashes
- [x] Verified the specific change that was causing the issue through incremental reverts

🤖 Generated with [Claude Code](https://claude.ai/code)