### PR TITLE
Refactor CGGenDemo to showcase cggen API usage examples

### DIFF
--- a/CGGenDemo/CGGenDemo.xcodeproj/xcshareddata/xcschemes/CGGenDemo.xcscheme
+++ b/CGGenDemo/CGGenDemo.xcodeproj/xcshareddata/xcschemes/CGGenDemo.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BBADE7712DF43C9D00179730"
+               BuildableName = "CGGenDemo.app"
+               BlueprintName = "CGGenDemo"
+               ReferencedContainer = "container:CGGenDemo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "NO"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BBADE7712DF43C9D00179730"
+            BuildableName = "CGGenDemo.app"
+            BlueprintName = "CGGenDemo"
+            ReferencedContainer = "container:CGGenDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BBADE7712DF43C9D00179730"
+            BuildableName = "CGGenDemo.app"
+            BlueprintName = "CGGenDemo"
+            ReferencedContainer = "container:CGGenDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/CGGenDemo/CGGenDemo/AppKitDemo.swift
+++ b/CGGenDemo/CGGenDemo/AppKitDemo.swift
@@ -3,16 +3,127 @@ import AppKit
 import CGGenRuntimeSupport
 import SwiftUI
 
-// Flipped view for proper coordinate system
-class FlippedView: NSView {
-  override var isFlipped: Bool { true }
-}
-
-// AppKit View Controller demonstrating cggen API usage
-class AppKitDemoViewController: NSViewController {
+// AppKit demo showing cggen API examples
+class AppKitDemoViewController: NSViewController, NSTableViewDataSource,
+  NSTableViewDelegate {
+  private let tableView = NSTableView()
   private let scrollView = NSScrollView()
-  private let contentView = FlippedView()
-  private var contentHeight: CGFloat = 0
+
+  struct Example {
+    let category: String
+    let code: String
+    let createView: () -> NSView
+  }
+
+  private let examples: [Example] = [
+    // NSImage Creation
+    Example(
+      category: "NSImage Creation",
+      code: "NSImage.draw(\\.star)",
+      createView: {
+        let imageView = NSImageView()
+        imageView.image = NSImage.draw(\.star)
+        imageView.imageScaling = .scaleProportionallyUpOrDown
+        return imageView
+      }
+    ),
+    Example(
+      category: "NSImage Creation",
+      code: "NSImage(drawing: .heart)",
+      createView: {
+        let imageView = NSImageView()
+        imageView.image = NSImage(drawing: .heart)
+        imageView.imageScaling = .scaleProportionallyUpOrDown
+        return imageView
+      }
+    ),
+
+    // Sizing
+    Example(
+      category: "Sizing",
+      code: "NSImage.draw(\\.gear, scale: 2.0)",
+      createView: {
+        let imageView = NSImageView()
+        imageView.image = NSImage.draw(\.gear, scale: 2.0)
+        imageView.imageScaling = .scaleProportionallyUpOrDown
+        return imageView
+      }
+    ),
+    Example(
+      category: "Sizing",
+      code: ".draw(\\.mountain, size: CGSize(40, 30), contentMode: .aspectFit)",
+      createView: {
+        let imageView = NSImageView()
+        imageView.image = NSImage.draw(
+          \.mountain,
+          size: CGSize(width: 40, height: 30),
+          contentMode: .aspectFit
+        )
+        imageView.imageScaling = .scaleNone
+        return imageView
+      }
+    ),
+
+    // Image Views
+    Example(
+      category: "NSImageView",
+      code: "imageView.image = NSImage(drawing: .rocket)",
+      createView: {
+        let imageView = NSImageView()
+        imageView.image = NSImage(drawing: .rocket)
+        imageView.imageScaling = .scaleProportionallyUpOrDown
+        imageView.wantsLayer = true
+        imageView.layer?.backgroundColor = NSColor.textBackgroundColor.cgColor
+        imageView.layer?.borderColor = NSColor.separatorColor.cgColor
+        imageView.layer?.borderWidth = 0.5
+        return imageView
+      }
+    ),
+    Example(
+      category: "NSImageView",
+      code: "imageView.imageScaling = .scaleNone",
+      createView: {
+        let imageView = NSImageView()
+        imageView.image = NSImage(drawing: .star)
+        imageView.imageScaling = .scaleNone
+        imageView.wantsLayer = true
+        imageView.layer?.backgroundColor = NSColor.textBackgroundColor.cgColor
+        imageView.layer?.borderColor = NSColor.separatorColor.cgColor
+        imageView.layer?.borderWidth = 0.5
+        return imageView
+      }
+    ),
+
+    // Interactive
+    Example(
+      category: "Interactive",
+      code: "NSButton(image: NSImage.draw(\\.gear))",
+      createView: {
+        let button = NSButton(
+          image: NSImage.draw(\.gear),
+          target: nil,
+          action: nil
+        )
+        button.bezelStyle = .rounded
+        return button
+      }
+    ),
+    Example(
+      category: "Interactive",
+      code: "button.image = NSImage.draw(\\.heart)",
+      createView: {
+        let button = NSButton(
+          title: "Like",
+          image: NSImage.draw(\.heart),
+          target: nil,
+          action: nil
+        )
+        button.imagePosition = .imageLeading
+        button.bezelStyle = .rounded
+        return button
+      }
+    ),
+  ]
 
   override func loadView() {
     view = NSView()
@@ -20,315 +131,152 @@ class AppKitDemoViewController: NSViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    setupViews()
-    addDemoSections()
+    setupTableView()
   }
 
   override func viewDidLayout() {
     super.viewDidLayout()
     scrollView.frame = view.bounds
-    contentView.frame = CGRect(
-      x: 0,
-      y: 0,
-      width: view.bounds.width,
-      height: contentHeight
-    )
   }
 
-  private func setupViews() {
+  private func setupTableView() {
     view.wantsLayer = true
 
     // Setup scroll view
     scrollView.hasVerticalScroller = true
     scrollView.borderType = .noBorder
+    scrollView.documentView = tableView
     view.addSubview(scrollView)
 
-    // Setup content view
-    scrollView.documentView = contentView
+    // Setup table view
+    tableView.style = .inset
+    tableView.rowHeight = 60
+    tableView.gridStyleMask = []
+    tableView.intercellSpacing = NSSize(width: 0, height: 1)
+
+    // Create columns
+    let iconColumn =
+      NSTableColumn(identifier: NSUserInterfaceItemIdentifier("icon"))
+    iconColumn.title = "Result"
+    iconColumn.width = 80
+    tableView.addTableColumn(iconColumn)
+
+    let codeColumn =
+      NSTableColumn(identifier: NSUserInterfaceItemIdentifier("code"))
+    codeColumn.title = "Code"
+    codeColumn.width = 400
+    tableView.addTableColumn(codeColumn)
+
+    tableView.dataSource = self
+    tableView.delegate = self
+
+    // Group by category
+    tableView.floatsGroupRows = true
   }
 
-  private func addDemoSections() {
-    var yOffset: CGFloat = 20
+  // MARK: - NSTableViewDataSource
 
-    // Section 1: Basic NSImage creation with KeyPath syntax
-    yOffset = addSection(
-      title: "NSImage Creation - KeyPath Syntax",
-      description: "Most concise syntax using KeyPath",
-      yOffset: yOffset
-    ) { containerView in
-      let imageView1 = NSImageView()
-      imageView1.image = NSImage.draw(\.star)
-      imageView1.imageScaling = .scaleProportionallyUpOrDown
-      imageView1.frame = CGRect(x: 16, y: 40, width: 16, height: 16)
-      containerView.addSubview(imageView1)
+  func numberOfRows(in _: NSTableView) -> Int {
+    // Count categories + examples
+    let categories = Set(examples.map { $0.category })
+    return categories.count + examples.count
+  }
 
-      let imageView2 = NSImageView()
-      imageView2.image = NSImage.draw(\.star, scale: 3.0)
-      imageView2.imageScaling = .scaleProportionallyUpOrDown
-      imageView2.frame = CGRect(x: 40, y: 40, width: 16, height: 16)
-      containerView.addSubview(imageView2)
+  func tableView(
+    _: NSTableView,
+    objectValueFor _: NSTableColumn?,
+    row _: Int
+  ) -> Any? {
+    nil
+  }
 
-      return 65
+  func tableView(_: NSTableView, isGroupRow row: Int) -> Bool {
+    var currentRow = 0
+    var lastCategory = ""
+
+    for example in examples {
+      if example.category != lastCategory {
+        if currentRow == row {
+          return true
+        }
+        lastCategory = example.category
+        currentRow += 1
+      }
+      if currentRow == row {
+        return false
+      }
+      currentRow += 1
     }
 
-    // Section 2: Direct initialization
-    yOffset = addSection(
-      title: "Direct NSImage Initialization",
-      description: "Create images with Drawing instances",
-      yOffset: yOffset
-    ) { containerView in
-      let imageView1 = NSImageView()
-      imageView1.image = NSImage(drawing: .heart)
-      imageView1.imageScaling = .scaleProportionallyUpOrDown
-      imageView1.frame = CGRect(x: 16, y: 40, width: 16, height: 16)
-      containerView.addSubview(imageView1)
+    return false
+  }
 
-      let imageView2 = NSImageView()
-      imageView2.image = NSImage(drawing: .rocket, scale: 2.0)
-      imageView2.imageScaling = .scaleProportionallyUpOrDown
-      imageView2.frame = CGRect(x: 40, y: 40, width: 24, height: 24)
-      containerView.addSubview(imageView2)
+  // MARK: - NSTableViewDelegate
 
-      return 70
+  func tableView(
+    _: NSTableView,
+    viewFor tableColumn: NSTableColumn?,
+    row: Int
+  ) -> NSView? {
+    var currentRow = 0
+    var lastCategory = ""
+    var categoryRows: [String: Int] = [:]
+
+    for example in examples {
+      if example.category != lastCategory {
+        categoryRows[example.category] = currentRow
+        lastCategory = example.category
+        currentRow += 1
+      }
+      if currentRow == row {
+        // This is a regular row
+        if tableColumn?.identifier.rawValue == "icon" {
+          let containerView = NSView()
+          let exampleView = example.createView()
+          exampleView.translatesAutoresizingMaskIntoConstraints = false
+          containerView.addSubview(exampleView)
+
+          NSLayoutConstraint.activate([
+            exampleView.centerXAnchor
+              .constraint(equalTo: containerView.centerXAnchor),
+            exampleView.centerYAnchor
+              .constraint(equalTo: containerView.centerYAnchor),
+            exampleView.widthAnchor.constraint(lessThanOrEqualToConstant: 50),
+            exampleView.heightAnchor.constraint(lessThanOrEqualToConstant: 50),
+          ])
+
+          return containerView
+        } else {
+          let textField = NSTextField(labelWithString: example.code)
+          textField.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+          textField.lineBreakMode = .byTruncatingTail
+          return textField
+        }
+      }
+      currentRow += 1
     }
 
-    // Section 3: Content modes
-    yOffset = addSection(
-      title: "Content Modes with Target Size",
-      description: "Generate images with specific size and content mode",
-      yOffset: yOffset
-    ) { containerView in
-      let fitImage = NSImage.draw(
-        \.mountain,
-        size: CGSize(width: 40, height: 30),
-        contentMode: .aspectFit
-      )
-
-      let fillImage = NSImage.draw(
-        \.mountain,
-        size: CGSize(width: 40, height: 30),
-        contentMode: .aspectFill
-      )
-
-      let fitView = createImageView(
-        image: fitImage,
-        frame: CGRect(x: 16, y: 40, width: 40, height: 30)
-      )
-      containerView.addSubview(fitView)
-
-      let fitLabel = createLabel(
-        text: "Aspect Fit",
-        frame: CGRect(x: 16, y: 74, width: 40, height: 16)
-      )
-      containerView.addSubview(fitLabel)
-
-      let fillView = createImageView(
-        image: fillImage,
-        frame: CGRect(x: 66, y: 40, width: 40, height: 30)
-      )
-      containerView.addSubview(fillView)
-
-      let fillLabel = createLabel(
-        text: "Aspect Fill",
-        frame: CGRect(x: 66, y: 74, width: 40, height: 16)
-      )
-      containerView.addSubview(fillLabel)
-
-      return 90
+    // Group row
+    if let category = categoryRows.first(where: { $0.value == row })?.key {
+      let textField = NSTextField(labelWithString: category)
+      textField.font = .systemFont(ofSize: 13, weight: .semibold)
+      textField.textColor = .secondaryLabelColor
+      return textField
     }
 
-    // Section 4: In NSButton
-    yOffset = addSection(
-      title: "Using in NSButton",
-      description: "Set button images easily",
-      yOffset: yOffset
-    ) { containerView in
-      let button1 = NSButton(
-        title: "Settings",
-        image: NSImage.draw(\.gear),
-        target: nil,
-        action: nil
-      )
-      button1.imagePosition = .imageLeading
-      button1.bezelStyle = .rounded
-      button1.frame = CGRect(x: 16, y: 40, width: 70, height: 22)
-      containerView.addSubview(button1)
+    return nil
+  }
 
-      let button2 = NSButton(
-        image: NSImage.draw(\.heart),
-        target: nil,
-        action: nil
-      )
-      button2.bezelStyle = .texturedRounded
-      button2.isBordered = true
-      button2.frame = CGRect(x: 92, y: 40, width: 30, height: 22)
-      containerView.addSubview(button2)
-
-      return 65
+  func tableView(
+    _ tableView: NSTableView,
+    rowViewForRow row: Int
+  ) -> NSTableRowView? {
+    if self.tableView(tableView, isGroupRow: row) {
+      let rowView = NSTableRowView()
+      rowView.isGroupRowStyle = true
+      return rowView
     }
-
-    // Section 5: NSImageView with different scaling modes
-    yOffset = addSection(
-      title: "NSImageView Scaling Modes",
-      description: "Standard AppKit scaling mode support",
-      yOffset: yOffset
-    ) { containerView in
-      let imageView1 = createImageView(
-        image: NSImage(drawing: .rocket),
-        frame: CGRect(x: 16, y: 40, width: 40, height: 40),
-        scaling: .scaleProportionallyUpOrDown
-      )
-      containerView.addSubview(imageView1)
-
-      let label1 = createLabel(
-        text: ".scaleProportionallyUpOrDown",
-        frame: CGRect(x: 16, y: 84, width: 40, height: 32)
-      )
-      label1.maximumNumberOfLines = 2
-      containerView.addSubview(label1)
-
-      let imageView2 = createImageView(
-        image: NSImage(drawing: .rocket),
-        frame: CGRect(x: 66, y: 40, width: 40, height: 40),
-        scaling: .scaleNone
-      )
-      containerView.addSubview(imageView2)
-
-      let label2 = createLabel(
-        text: ".scaleNone",
-        frame: CGRect(x: 66, y: 84, width: 40, height: 16)
-      )
-      containerView.addSubview(label2)
-
-      return 120
-    }
-
-    // Section 6: Drawing in custom NSView
-    yOffset = addSection(
-      title: "Custom NSView Drawing",
-      description: "Draw directly in NSView subclass",
-      yOffset: yOffset
-    ) { containerView in
-      let customView = CustomDrawingView(drawing: .star)
-      customView.frame = CGRect(x: 16, y: 40, width: 40, height: 40)
-      containerView.addSubview(customView)
-
-      return 90
-    }
-
-    contentHeight = yOffset
-  }
-
-  // Helper method for creating sections
-  private func addSection(
-    title: String,
-    description: String,
-    yOffset: CGFloat,
-    content: (NSView) -> CGFloat
-  ) -> CGFloat {
-    let containerView = NSView()
-    containerView.wantsLayer = true
-    containerView.layer?.backgroundColor = NSColor.controlBackgroundColor
-      .cgColor
-    containerView.layer?.cornerRadius = 8
-
-    let titleLabel = NSTextField(labelWithString: title)
-    titleLabel.font = .preferredFont(forTextStyle: .headline)
-    titleLabel.frame = CGRect(
-      x: 16,
-      y: 0,
-      width: view.bounds.width - 64,
-      height: 22
-    )
-    containerView.addSubview(titleLabel)
-
-    let descLabel = NSTextField(labelWithString: description)
-    descLabel.font = .preferredFont(forTextStyle: .caption1)
-    descLabel.textColor = .secondaryLabelColor
-    descLabel.frame = CGRect(
-      x: 16,
-      y: 20,
-      width: view.bounds.width - 64,
-      height: 16
-    )
-    containerView.addSubview(descLabel)
-
-    let contentHeight = content(containerView)
-
-    // Don't flip coordinates - just position from top
-    containerView.frame = CGRect(
-      x: 20,
-      y: yOffset,
-      width: view.bounds.width - 40,
-      height: contentHeight
-    )
-
-    contentView.addSubview(containerView)
-
-    return yOffset + contentHeight + 15
-  }
-
-  private func createImageView(
-    image: NSImage?,
-    frame: CGRect,
-    scaling: NSImageScaling = .scaleProportionallyUpOrDown
-  ) -> NSImageView {
-    let imageView = NSImageView()
-    imageView.image = image
-    imageView.imageScaling = scaling
-    imageView.wantsLayer = true
-    imageView.layer?.backgroundColor = NSColor.textBackgroundColor.cgColor
-    imageView.layer?.borderColor = NSColor.separatorColor.cgColor
-    imageView.layer?.borderWidth = 1
-    imageView.frame = frame
-    return imageView
-  }
-
-  private func createLabel(text: String, frame: CGRect) -> NSTextField {
-    let label = NSTextField(labelWithString: text)
-    label.font = .preferredFont(forTextStyle: .caption1)
-    label.textColor = .secondaryLabelColor
-    label.alignment = .center
-    label.frame = frame
-    return label
-  }
-}
-
-// Custom NSView that draws directly
-class CustomDrawingView: NSView {
-  let drawing: Drawing
-
-  init(drawing: Drawing) {
-    self.drawing = drawing
-    super.init(frame: .zero)
-    wantsLayer = true
-    layer?.backgroundColor = NSColor.textBackgroundColor.cgColor
-    layer?.borderColor = NSColor.separatorColor.cgColor
-    layer?.borderWidth = 1
-  }
-
-  @available(*, unavailable)
-  required init?(coder _: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
-
-  override func draw(_ dirtyRect: NSRect) {
-    super.draw(dirtyRect)
-
-    guard let context = NSGraphicsContext.current?.cgContext else { return }
-
-    // Center the drawing
-    let drawingRect = CGRect(
-      x: (bounds.width - drawing.size.width) / 2,
-      y: (bounds.height - drawing.size.height) / 2,
-      width: drawing.size.width,
-      height: drawing.size.height
-    )
-
-    context.saveGState()
-    context.translateBy(x: drawingRect.minX, y: drawingRect.minY)
-    drawing.draw(context)
-    context.restoreGState()
+    return nil
   }
 }
 

--- a/CGGenDemo/CGGenDemo/CGGenDemoApp.swift
+++ b/CGGenDemo/CGGenDemo/CGGenDemoApp.swift
@@ -9,6 +9,9 @@ enum DemoTab: String, CaseIterable, ExpressibleByArgument {
 
 struct CLIArgs: ParsableArguments {
   @Option var tab: DemoTab = .swiftui
+
+  // Capture all unrecognized arguments to prevent errors
+  @Argument(parsing: .allUnrecognized) var unrecognized: [String] = []
 }
 
 @main

--- a/CGGenDemo/CGGenDemo/Images/gear.svg
+++ b/CGGenDemo/CGGenDemo/Images/gear.svg
@@ -1,16 +1,16 @@
-<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
-  <g transform="translate(60,60)">
-    <circle r="20" fill="#696969"/>
+<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(20,20)">
+    <circle r="7" fill="#696969"/>
     <g fill="#696969">
-      <rect x="-10" y="-50" width="20" height="30" rx="4"/>
-      <rect x="-10" y="20" width="20" height="30" rx="4"/>
-      <rect x="-50" y="-10" width="30" height="20" rx="4"/>
-      <rect x="20" y="-10" width="30" height="20" rx="4"/>
+      <rect x="-3.5" y="-17" width="7" height="10" rx="1.5"/>
+      <rect x="-3.5" y="7" width="7" height="10" rx="1.5"/>
+      <rect x="-17" y="-3.5" width="10" height="7" rx="1.5"/>
+      <rect x="7" y="-3.5" width="10" height="7" rx="1.5"/>
       <g transform="rotate(45)">
-        <rect x="-10" y="-50" width="20" height="30" rx="4"/>
-        <rect x="-10" y="20" width="20" height="30" rx="4"/>
-        <rect x="-50" y="-10" width="30" height="20" rx="4"/>
-        <rect x="20" y="-10" width="30" height="20" rx="4"/>
+        <rect x="-3.5" y="-17" width="7" height="10" rx="1.5"/>
+        <rect x="-3.5" y="7" width="7" height="10" rx="1.5"/>
+        <rect x="-17" y="-3.5" width="10" height="7" rx="1.5"/>
+        <rect x="7" y="-3.5" width="10" height="7" rx="1.5"/>
       </g>
     </g>
   </g>

--- a/CGGenDemo/CGGenDemo/Images/heart.svg
+++ b/CGGenDemo/CGGenDemo/Images/heart.svg
@@ -1,3 +1,3 @@
-<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-  <path d="M50 30 C30 10, 10 20, 10 40 C10 60, 50 90, 50 90 C50 90, 90 60, 90 40 C90 20, 70 10, 50 30 Z" fill="#FF69B4" stroke="#FF1493" stroke-width="2"/>
+<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+  <path d="M20 12 C12 4, 4 8, 4 16 C4 24, 20 36, 20 36 C20 36, 36 24, 36 16 C36 8, 28 4, 20 12 Z" fill="#FF69B4" stroke="#FF1493" stroke-width="1"/>
 </svg>

--- a/CGGenDemo/CGGenDemo/Images/mountain.svg
+++ b/CGGenDemo/CGGenDemo/Images/mountain.svg
@@ -1,28 +1,28 @@
-<svg width="100" height="80" viewBox="0 0 100 80" xmlns="http://www.w3.org/2000/svg">
+<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
   <!-- Sky background -->
-  <rect width="100" height="80" fill="#87CEEB"/>
+  <rect width="40" height="40" fill="#87CEEB"/>
   
   <!-- Sun -->
-  <circle cx="75" cy="20" r="8" fill="#FFD700"/>
+  <circle cx="30" cy="8" r="3" fill="#FFD700"/>
   
   <!-- Back mountain -->
-  <path d="M0 50 L30 20 L60 50 L60 80 L0 80 Z" fill="#6B7280"/>
+  <path d="M0 25 L12 10 L24 25 L24 40 L0 40 Z" fill="#6B7280"/>
   
   <!-- Front mountain -->
-  <path d="M30 45 L50 25 L70 45 L85 30 L100 45 L100 80 L30 80 Z" fill="#374151"/>
+  <path d="M12 22 L20 12 L28 22 L34 15 L40 22 L40 40 L12 40 Z" fill="#374151"/>
   
   <!-- Snow caps -->
-  <path d="M30 20 L20 30 L40 30 Z" fill="white"/>
-  <path d="M50 25 L42 33 L58 33 Z" fill="white"/>
-  <path d="M85 30 L78 37 L92 37 Z" fill="white"/>
+  <path d="M12 10 L8 14 L16 14 Z" fill="white"/>
+  <path d="M20 12 L17 15 L23 15 Z" fill="white"/>
+  <path d="M34 15 L31 18 L37 18 Z" fill="white"/>
   
   <!-- Trees -->
-  <path d="M10 65 L15 55 L20 65 Z" fill="#065F46"/>
-  <path d="M12 70 L15 65 L18 70 Z" fill="#047857"/>
+  <path d="M4 32 L6 28 L8 32 Z" fill="#065F46"/>
+  <path d="M5 35 L6 32 L7 35 Z" fill="#047857"/>
   
-  <path d="M25 68 L28 60 L31 68 Z" fill="#065F46"/>
-  <path d="M26 72 L28 68 L30 72 Z" fill="#047857"/>
+  <path d="M10 34 L11 30 L12 34 Z" fill="#065F46"/>
+  <path d="M10.5 36 L11 34 L11.5 36 Z" fill="#047857"/>
   
-  <path d="M70 63 L74 54 L78 63 Z" fill="#065F46"/>
-  <path d="M71 68 L74 63 L77 68 Z" fill="#047857"/>
+  <path d="M28 31 L29.5 27 L31 31 Z" fill="#065F46"/>
+  <path d="M28.5 34 L29.5 31 L30.5 34 Z" fill="#047857"/>
 </svg>

--- a/CGGenDemo/CGGenDemo/Images/rocket.svg
+++ b/CGGenDemo/CGGenDemo/Images/rocket.svg
@@ -1,20 +1,20 @@
-<svg width="80" height="100" viewBox="0 0 80 100" xmlns="http://www.w3.org/2000/svg">
+<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
   <!-- Rocket body -->
-  <path d="M40 5 C35 5 30 10 30 20 L30 60 C30 65 35 70 40 70 C45 70 50 65 50 60 L50 20 C50 10 45 5 40 5" fill="#3B82F6"/>
+  <path d="M20 2 C17.5 2 15 4.5 15 9 L15 24 C15 26 17.5 28 20 28 C22.5 28 25 26 25 24 L25 9 C25 4.5 22.5 2 20 2" fill="#3B82F6"/>
   
   <!-- Rocket nose cone -->
-  <path d="M40 5 C38 2 37 0 40 0 C43 0 42 2 40 5" fill="#1E40AF"/>
+  <path d="M20 2 C19 0.8 18.5 0 20 0 C21.5 0 21 0.8 20 2" fill="#1E40AF"/>
   
   <!-- Window -->
-  <circle cx="40" cy="25" r="8" fill="#60A5FA" stroke="#1E40AF" stroke-width="2"/>
-  <circle cx="40" cy="25" r="6" fill="#DBEAFE"/>
+  <circle cx="20" cy="10" r="3.5" fill="#60A5FA" stroke="#1E40AF" stroke-width="1"/>
+  <circle cx="20" cy="10" r="2.5" fill="#DBEAFE"/>
   
   <!-- Fins -->
-  <path d="M30 45 L15 60 L15 65 L30 55 Z" fill="#EF4444"/>
-  <path d="M50 45 L65 60 L65 65 L50 55 Z" fill="#EF4444"/>
+  <path d="M15 18 L7.5 24 L7.5 26 L15 22 Z" fill="#EF4444"/>
+  <path d="M25 18 L32.5 24 L32.5 26 L25 22 Z" fill="#EF4444"/>
   
   <!-- Exhaust flames -->
-  <path d="M35 70 C35 75 33 80 35 85 C37 90 38 95 40 100 C42 95 43 90 45 85 C47 80 45 75 45 70" fill="#FCD34D"/>
-  <path d="M37 70 C37 74 36 78 37 82 C38 86 39 90 40 94 C41 90 42 86 43 82 C44 78 43 74 43 70" fill="#FB923C"/>
-  <path d="M39 70 C39 73 38.5 76 39 79 C39.5 82 39.5 85 40 88 C40.5 85 40.5 82 41 79 C41.5 76 41 73 41 70" fill="#EF4444"/>
+  <path d="M17.5 28 C17.5 30 16.5 32 17.5 34 C18.5 36 19 38 20 40 C21 38 21.5 36 22.5 34 C23.5 32 22.5 30 22.5 28" fill="#FCD34D"/>
+  <path d="M18.5 28 C18.5 29.5 18 31 18.5 32.5 C19 34 19.5 35.5 20 37 C20.5 35.5 21 34 21.5 32.5 C22 31 21.5 29.5 21.5 28" fill="#FB923C"/>
+  <path d="M19.5 28 C19.5 29 19.25 30 19.5 31 C19.75 32 19.75 33 20 34 C20.25 33 20.25 32 20.5 31 C20.75 30 20.5 29 20.5 28" fill="#EF4444"/>
 </svg>

--- a/CGGenDemo/CGGenDemo/Images/star.svg
+++ b/CGGenDemo/CGGenDemo/Images/star.svg
@@ -1,3 +1,3 @@
-<svg width="80" height="80" viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg">
-  <path d="M40 10 L47 30 L68 30 L51 42 L58 62 L40 50 L22 62 L29 42 L12 30 L33 30 Z" fill="#FFD700" stroke="#FFA500" stroke-width="2"/>
+<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+  <path d="M20 5 L23.5 15 L34 15 L25.5 21 L29 31 L20 25 L11 31 L14.5 21 L6 15 L16.5 15 Z" fill="#FFD700" stroke="#FFA500" stroke-width="1"/>
 </svg>

--- a/CGGenDemo/CGGenDemo/SwiftUIDemo.swift
+++ b/CGGenDemo/CGGenDemo/SwiftUIDemo.swift
@@ -3,165 +3,121 @@ import SwiftUI
 
 struct SwiftUIDemo: View {
   var body: some View {
-    ScrollView {
-      VStack(alignment: .leading, spacing: 15) {
-        Text("SwiftUI API Examples")
-          .font(.title3)
-          .padding(.top, 10)
-
-        // Direct usage as SwiftUI Views
-        Section("Direct View Usage") {
-          VStack(alignment: .leading, spacing: 8) {
-            Text("Drawings conform to View protocol")
-              .font(.caption)
-              .foregroundColor(.secondary)
-
-            HStack(spacing: 10) {
-              Drawing.star
-                .frame(width: 16, height: 16)
-              Drawing.heart
-                .frame(width: 16, height: 16)
-              Drawing.gear
-                .frame(width: 16, height: 16)
-              Drawing.rocket
-                .frame(width: 24, height: 24)
-              Drawing.mountain
-                .frame(width: 30, height: 24)
-            }
-          }
+    List {
+      // Direct Drawing usage
+      Section("Drawing as View") {
+        HStack {
+          Drawing.star
+            .frame(width: 30, height: 30)
+          Spacer()
+          Text("Drawing.star")
         }
 
-        // With SwiftUI modifiers
-        Section("With Modifiers") {
-          VStack(alignment: .leading, spacing: 8) {
-            Text("Works with standard SwiftUI modifiers")
-              .font(.caption)
-              .foregroundColor(.secondary)
-
-            HStack(spacing: 10) {
-              Drawing.heart
-                .foregroundColor(.red)
-                .frame(width: 16, height: 16)
-
-              Drawing.star
-                .foregroundColor(.yellow)
-                .frame(width: 16, height: 16)
-                .scaleEffect(1.2)
-
-              Drawing.gear
-                .foregroundColor(.gray)
-                .frame(width: 16, height: 16)
-                .rotationEffect(.degrees(45))
-            }
-          }
-        }
-
-        // In buttons
-        Section("In Buttons") {
-          VStack(alignment: .leading, spacing: 8) {
-            Text("Use directly in button labels")
-              .font(.caption)
-              .foregroundColor(.secondary)
-
-            HStack(spacing: 10) {
-              Button(action: {}) {
-                Drawing.rocket
-                  .frame(width: 14, height: 14)
-              }
-              .buttonStyle(.borderedProminent)
-
-              Button(action: {}) {
-                HStack(spacing: 4) {
-                  Drawing.star
-                    .frame(width: 12, height: 12)
-                  Text("Favorite")
-                    .font(.caption)
-                }
-              }
-              .buttonStyle(.bordered)
-            }
-          }
-        }
-
-        // With aspect ratio
-        Section("Aspect Ratio Examples") {
-          VStack(alignment: .leading, spacing: 8) {
-            Text("Standard aspect ratio modifiers")
-              .font(.caption)
-              .foregroundColor(.secondary)
-
-            HStack(spacing: 10) {
-              VStack(spacing: 4) {
-                Drawing.mountain
-                  .aspectRatio(contentMode: .fit)
-                  .frame(width: 40, height: 30)
-                  .border(Color.gray, width: 0.5)
-                Text("Fit")
-                  .font(.caption2)
-              }
-
-              VStack(spacing: 4) {
-                Drawing.mountain
-                  .aspectRatio(contentMode: .fill)
-                  .frame(width: 40, height: 30)
-                  .clipped()
-                  .border(Color.gray, width: 0.5)
-                Text("Fill")
-                  .font(.caption2)
-              }
-            }
-          }
-        }
-
-        // As images
-        Section("As SwiftUI Images") {
-          VStack(alignment: .leading, spacing: 8) {
-            Text("Convert to Image for more control")
-              .font(.caption)
-              .foregroundColor(.secondary)
-
-            HStack(spacing: 10) {
-              Image(drawing: .gear)
-                .resizable()
-                .frame(width: 16, height: 16)
-
-              Image(drawing: .star, scale: 2.0)
-                .foregroundColor(.orange)
-                .frame(width: 16, height: 16)
-            }
-          }
+        HStack {
+          Drawing.heart
+            .foregroundColor(.red)
+            .frame(width: 30, height: 30)
+          Spacer()
+          Text("Drawing.heart.foregroundColor(.red)")
         }
       }
-      .padding()
+
+      // Frame and sizing
+      Section("Sizing") {
+        HStack {
+          Drawing.gear
+            .frame(width: 30, height: 30)
+          Spacer()
+          Text(".frame(width: 30, height: 30)")
+        }
+
+        HStack {
+          Drawing.mountain
+            .aspectRatio(contentMode: .fit)
+            .frame(height: 40)
+            .background(Color.gray.opacity(0.1))
+          Spacer()
+          Text(".aspectRatio(contentMode: .fit)")
+        }
+      }
+
+      // Image conversion
+      Section("Image(drawing:)") {
+        HStack {
+          Image(drawing: .rocket)
+            .resizable()
+            .frame(width: 30, height: 30)
+          Spacer()
+          Text("Image(drawing: .rocket).resizable()")
+        }
+
+        HStack {
+          Image(drawing: .star, scale: 2.0)
+            .foregroundColor(.orange)
+          Spacer()
+          Text("Image(drawing: .star, scale: 2.0)")
+        }
+      }
+
+      // Modifiers
+      Section("Modifiers") {
+        HStack {
+          Drawing.gear
+            .rotationEffect(.degrees(45))
+            .frame(width: 30, height: 30)
+          Spacer()
+          Text(".rotationEffect(.degrees(45))")
+        }
+
+        HStack {
+          Drawing.heart
+            .scaleEffect(1.5)
+            .foregroundColor(.pink)
+            .frame(width: 45, height: 45)
+          Spacer()
+          Text(".scaleEffect(1.5)")
+        }
+
+        HStack {
+          Drawing.rocket
+            .opacity(0.5)
+            .frame(width: 30, height: 30)
+          Spacer()
+          Text(".opacity(0.5)")
+        }
+      }
+
+      // In buttons
+      Section("Interactive") {
+        HStack {
+          Button(action: {}) {
+            Drawing.star
+              .frame(width: 20, height: 20)
+          }
+          .buttonStyle(.bordered)
+          Spacer()
+          Text("Button with Drawing")
+        }
+
+        HStack {
+          Button(action: {}) {
+            Label {
+              Text("Navigate")
+            } icon: {
+              Drawing.mountain
+                .frame(width: 16, height: 16)
+            }
+          }
+          .buttonStyle(.borderedProminent)
+          Spacer()
+          Text("Label with icon")
+        }
+      }
     }
     .navigationTitle("SwiftUI API")
     #if os(iOS)
       .navigationBarTitleDisplayMode(.inline)
     #endif
-  }
-}
-
-// Helper view for sections
-struct Section<Content: View>: View {
-  let title: String
-  let content: () -> Content
-
-  init(_ title: String, @ViewBuilder content: @escaping () -> Content) {
-    self.title = title
-    self.content = content
-  }
-
-  var body: some View {
-    VStack(alignment: .leading, spacing: 8) {
-      Text(title)
-        .font(.subheadline)
-        .fontWeight(.semibold)
-
-      content()
-        .padding(10)
-        .background(Color.gray.opacity(0.05))
-        .cornerRadius(6)
-    }
   }
 }
 

--- a/CGGenDemo/CGGenDemo/UIKitDemo.swift
+++ b/CGGenDemo/CGGenDemo/UIKitDemo.swift
@@ -3,235 +3,302 @@ import CGGenRuntimeSupport
 import SwiftUI
 import UIKit
 
+// Example model for table view
+struct UIKitExample {
+  var code: String
+  var createView: () -> UIView
+}
+
 // UIKit View Controller demonstrating cggen API usage
 class UIKitDemoViewController: UIViewController {
-  private let scrollView = UIScrollView()
-  private var contentHeight: CGFloat = 0
+  private let tableView = UITableView(frame: .zero, style: .grouped)
+  private var examples: [(category: String, items: [UIKitExample])] = []
 
   override func viewDidLoad() {
     super.viewDidLoad()
+    setupExamples()
     setupViews()
-    addDemoSections()
   }
 
-  override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
-    scrollView.frame = view.bounds
-    scrollView.contentSize = CGSize(
-      width: view.bounds.width,
-      height: contentHeight + 20
-    )
+  private func setupExamples() {
+    examples = [
+      (
+        category: "UIImage Creation",
+        items: [
+          UIKitExample(
+            code: "UIImage.draw(\\.star)",
+            createView: {
+              let imageView = UIImageView(image: UIImage.draw(\.star))
+              imageView.contentMode = .scaleAspectFit
+              imageView.frame = CGRect(x: 0, y: 0, width: 30, height: 30)
+              return imageView
+            }
+          ),
+          UIKitExample(
+            code: "UIImage(drawing: .heart)",
+            createView: {
+              let imageView = UIImageView(image: UIImage(drawing: .heart))
+              imageView.contentMode = .scaleAspectFit
+              imageView.frame = CGRect(x: 0, y: 0, width: 30, height: 30)
+              return imageView
+            }
+          ),
+          UIKitExample(
+            code: "UIImage.draw(\\.rocket, scale: 3.0)",
+            createView: {
+              let imageView = UIImageView(image: UIImage.draw(
+                \.rocket,
+                scale: 3.0
+              ))
+              imageView.contentMode = .scaleAspectFit
+              imageView.frame = CGRect(x: 0, y: 0, width: 30, height: 30)
+              return imageView
+            }
+          ),
+        ]
+      ),
+      (
+        category: "Sizing",
+        items: [
+          UIKitExample(
+            code: "UIImage.draw(\\.mountain,\n  size: CGSize(width: 60, height: 40),\n  contentMode: .aspectFit)",
+            createView: {
+              let imageView = UIImageView(
+                image: UIImage.draw(
+                  \.mountain,
+                  size: CGSize(width: 60, height: 40),
+                  contentMode: .aspectFit
+                )
+              )
+              imageView.contentMode = .scaleAspectFit
+              imageView.backgroundColor = .systemGray6
+              imageView.layer.borderColor = UIColor.systemGray4.cgColor
+              imageView.layer.borderWidth = 1
+              imageView.frame = CGRect(x: 0, y: 0, width: 60, height: 40)
+              return imageView
+            }
+          ),
+          UIKitExample(
+            code: "UIImage.draw(\\.mountain,\n  size: CGSize(width: 60, height: 40),\n  contentMode: .aspectFill)",
+            createView: {
+              let imageView = UIImageView(
+                image: UIImage.draw(
+                  \.mountain,
+                  size: CGSize(width: 60, height: 40),
+                  contentMode: .aspectFill
+                )
+              )
+              imageView.contentMode = .scaleAspectFit
+              imageView.backgroundColor = .systemGray6
+              imageView.layer.borderColor = UIColor.systemGray4.cgColor
+              imageView.layer.borderWidth = 1
+              imageView.frame = CGRect(x: 0, y: 0, width: 60, height: 40)
+              return imageView
+            }
+          ),
+        ]
+      ),
+      (
+        category: "UIButton Integration",
+        items: [
+          UIKitExample(
+            code: "button.setImage(UIImage.draw(\\.gear), for: .normal)",
+            createView: {
+              let button = UIButton(type: .system)
+              button.setImage(UIImage.draw(\.gear), for: .normal)
+              button.setTitle(" Settings", for: .normal)
+              button.frame = CGRect(x: 0, y: 0, width: 100, height: 44)
+              return button
+            }
+          ),
+          UIKitExample(
+            code: "// Tinted button\nbutton.setImage(UIImage.draw(\\.heart), for: .normal)\nbutton.tintColor = .systemRed",
+            createView: {
+              let button = UIButton(type: .system)
+              button.setImage(UIImage.draw(\.heart), for: .normal)
+              button.tintColor = .systemRed
+              button.frame = CGRect(x: 0, y: 0, width: 44, height: 44)
+              return button
+            }
+          ),
+        ]
+      ),
+      (
+        category: "UIImageView Content Modes",
+        items: [
+          UIKitExample(
+            code: "imageView.image = UIImage(drawing: .rocket)\nimageView.contentMode = .scaleAspectFit",
+            createView: {
+              let imageView = UIImageView(image: UIImage(drawing: .rocket))
+              imageView.contentMode = .scaleAspectFit
+              imageView.backgroundColor = .systemGray6
+              imageView.layer.borderColor = UIColor.systemGray4.cgColor
+              imageView.layer.borderWidth = 1
+              imageView.frame = CGRect(x: 0, y: 0, width: 60, height: 60)
+              return imageView
+            }
+          ),
+          UIKitExample(
+            code: "imageView.image = UIImage(drawing: .star)\nimageView.contentMode = .center",
+            createView: {
+              let imageView = UIImageView(image: UIImage(drawing: .star))
+              imageView.contentMode = .center
+              imageView.backgroundColor = .systemGray6
+              imageView.layer.borderColor = UIColor.systemGray4.cgColor
+              imageView.layer.borderWidth = 1
+              imageView.frame = CGRect(x: 0, y: 0, width: 60, height: 60)
+              return imageView
+            }
+          ),
+        ]
+      ),
+    ]
   }
 
   private func setupViews() {
     view.backgroundColor = .systemBackground
-    view.addSubview(scrollView)
+
+    tableView.delegate = self
+    tableView.dataSource = self
+    tableView.register(
+      UIKitExampleCell.self,
+      forCellReuseIdentifier: "ExampleCell"
+    )
+    tableView.rowHeight = UITableView.automaticDimension
+    tableView.estimatedRowHeight = 100
+
+    view.addSubview(tableView)
   }
 
-  private func addDemoSections() {
-    var yOffset: CGFloat = 20
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+    tableView.frame = view.bounds
+  }
+}
 
-    // Section 1: Basic UIImage creation with KeyPath syntax
-    yOffset = addSection(
-      title: "UIImage Creation - KeyPath Syntax",
-      description: "Most concise syntax using KeyPath",
-      yOffset: yOffset
-    ) { containerView in
-      let imageView1 = UIImageView(image: UIImage.draw(\.star))
-      imageView1.frame = CGRect(x: 16, y: 40, width: 16, height: 16)
-      imageView1.contentMode = .scaleAspectFit
-      containerView.addSubview(imageView1)
+// MARK: - UITableView DataSource & Delegate
 
-      let imageView2 = UIImageView(image: UIImage.draw(\.star, scale: 3.0))
-      imageView2.frame = CGRect(x: 40, y: 40, width: 16, height: 16)
-      imageView2.contentMode = .scaleAspectFit
-      containerView.addSubview(imageView2)
-
-      return 70
-    }
-
-    // Section 2: Direct initialization
-    yOffset = addSection(
-      title: "Direct UIImage Initialization",
-      description: "Create images with Drawing instances",
-      yOffset: yOffset
-    ) { containerView in
-      let imageView1 = UIImageView(image: UIImage(drawing: .heart))
-      imageView1.frame = CGRect(x: 16, y: 40, width: 16, height: 16)
-      imageView1.contentMode = .scaleAspectFit
-      containerView.addSubview(imageView1)
-
-      let imageView2 = UIImageView(image: UIImage(drawing: .rocket, scale: 2.0))
-      imageView2.frame = CGRect(x: 40, y: 40, width: 24, height: 24)
-      imageView2.contentMode = .scaleAspectFit
-      containerView.addSubview(imageView2)
-
-      return 80
-    }
-
-    // Section 3: Content modes
-    yOffset = addSection(
-      title: "Content Modes with Target Size",
-      description: "Generate images with specific size and content mode",
-      yOffset: yOffset
-    ) { containerView in
-      let fitImage = UIImage.draw(
-        \.mountain,
-        size: CGSize(width: 40, height: 30),
-        contentMode: .aspectFit
-      )
-
-      let fillImage = UIImage.draw(
-        \.mountain,
-        size: CGSize(width: 40, height: 30),
-        contentMode: .aspectFill
-      )
-
-      let fitView = UIImageView(image: fitImage)
-      fitView.frame = CGRect(x: 16, y: 40, width: 40, height: 30)
-      fitView.backgroundColor = .systemGray6
-      fitView.layer.borderColor = UIColor.systemGray4.cgColor
-      fitView.layer.borderWidth = 1
-      containerView.addSubview(fitView)
-
-      let fitLabel = UILabel()
-      fitLabel.text = "Aspect Fit"
-      fitLabel.font = .preferredFont(forTextStyle: .caption2)
-      fitLabel.textColor = .secondaryLabel
-      fitLabel.frame = CGRect(x: 16, y: 74, width: 40, height: 16)
-      fitLabel.textAlignment = .center
-      containerView.addSubview(fitLabel)
-
-      let fillView = UIImageView(image: fillImage)
-      fillView.frame = CGRect(x: 66, y: 40, width: 40, height: 30)
-      fillView.backgroundColor = .systemGray6
-      fillView.layer.borderColor = UIColor.systemGray4.cgColor
-      fillView.layer.borderWidth = 1
-      containerView.addSubview(fillView)
-
-      let fillLabel = UILabel()
-      fillLabel.text = "Aspect Fill"
-      fillLabel.font = .preferredFont(forTextStyle: .caption2)
-      fillLabel.textColor = .secondaryLabel
-      fillLabel.frame = CGRect(x: 66, y: 74, width: 40, height: 16)
-      fillLabel.textAlignment = .center
-      containerView.addSubview(fillLabel)
-
-      return 90
-    }
-
-    // Section 4: In UIButton
-    yOffset = addSection(
-      title: "Using in UIButton",
-      description: "Set button images easily",
-      yOffset: yOffset
-    ) { containerView in
-      let button1 = UIButton(type: .system)
-      button1.setImage(UIImage.draw(\.gear), for: .normal)
-      button1.setTitle(" Settings", for: .normal)
-      button1.frame = CGRect(x: 16, y: 40, width: 80, height: 30)
-      containerView.addSubview(button1)
-
-      let button2 = UIButton(type: .system)
-      button2.setImage(UIImage.draw(\.heart), for: .normal)
-      button2.tintColor = .systemRed
-      button2.frame = CGRect(x: 106, y: 40, width: 30, height: 30)
-      containerView.addSubview(button2)
-
-      return 80
-    }
-
-    // Section 5: UIImageView with different content modes
-    yOffset = addSection(
-      title: "UIImageView Content Modes",
-      description: "Standard UIKit content mode support",
-      yOffset: yOffset
-    ) { containerView in
-      let imageView1 = UIImageView(image: UIImage(drawing: .rocket))
-      imageView1.contentMode = .scaleAspectFit
-      imageView1.backgroundColor = .systemGray6
-      imageView1.layer.borderColor = UIColor.systemGray4.cgColor
-      imageView1.layer.borderWidth = 1
-      imageView1.frame = CGRect(x: 16, y: 40, width: 40, height: 40)
-      containerView.addSubview(imageView1)
-
-      let label1 = UILabel()
-      label1.text = ".scaleAspectFit"
-      label1.font = .preferredFont(forTextStyle: .caption2)
-      label1.textColor = .secondaryLabel
-      label1.frame = CGRect(x: 16, y: 84, width: 40, height: 32)
-      label1.textAlignment = .center
-      label1.numberOfLines = 2
-      containerView.addSubview(label1)
-
-      let imageView2 = UIImageView(image: UIImage(drawing: .rocket))
-      imageView2.contentMode = .center
-      imageView2.backgroundColor = .systemGray6
-      imageView2.layer.borderColor = UIColor.systemGray4.cgColor
-      imageView2.layer.borderWidth = 1
-      imageView2.frame = CGRect(x: 66, y: 40, width: 40, height: 40)
-      containerView.addSubview(imageView2)
-
-      let label2 = UILabel()
-      label2.text = ".center"
-      label2.font = .preferredFont(forTextStyle: .caption2)
-      label2.textColor = .secondaryLabel
-      label2.frame = CGRect(x: 66, y: 84, width: 40, height: 16)
-      label2.textAlignment = .center
-      containerView.addSubview(label2)
-
-      return 120
-    }
-
-    contentHeight = yOffset
+extension UIKitDemoViewController: UITableViewDataSource, UITableViewDelegate {
+  func numberOfSections(in _: UITableView) -> Int {
+    examples.count
   }
 
-  // Helper method for creating sections
-  private func addSection(
-    title: String,
-    description: String,
-    yOffset: CGFloat,
-    content: (UIView) -> CGFloat
-  ) -> CGFloat {
-    let containerView = UIView()
-    containerView.backgroundColor = .systemGray6
-    containerView.layer.cornerRadius = 8
+  func tableView(_: UITableView, numberOfRowsInSection section: Int) -> Int {
+    examples[section].items.count
+  }
 
-    let titleLabel = UILabel()
-    titleLabel.text = title
-    titleLabel.font = .preferredFont(forTextStyle: .headline)
-    titleLabel.frame = CGRect(
-      x: 16,
+  func tableView(
+    _: UITableView,
+    titleForHeaderInSection section: Int
+  ) -> String? {
+    examples[section].category
+  }
+
+  func tableView(
+    _ tableView: UITableView,
+    cellForRowAt indexPath: IndexPath
+  ) -> UITableViewCell {
+    let cell = tableView.dequeueReusableCell(
+      withIdentifier: "ExampleCell",
+      for: indexPath
+    ) as! UIKitExampleCell
+    let example = examples[indexPath.section].items[indexPath.row]
+    cell.configure(with: example)
+    return cell
+  }
+}
+
+// Custom cell for displaying examples
+class UIKitExampleCell: UITableViewCell {
+  private let codeLabel = UILabel()
+  private let containerView = UIView()
+  private var exampleView: UIView?
+
+  override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    super.init(style: style, reuseIdentifier: reuseIdentifier)
+    setupCell()
+  }
+
+  @available(*, unavailable)
+  required init?(coder _: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  private func setupCell() {
+    selectionStyle = .none
+
+    codeLabel.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+    codeLabel.textColor = .label
+    codeLabel.numberOfLines = 0
+
+    contentView.addSubview(codeLabel)
+    contentView.addSubview(containerView)
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+
+    let padding: CGFloat = 16
+    let spacing: CGFloat = 8
+
+    // Layout code label
+    let labelSize = codeLabel.sizeThatFits(CGSize(
+      width: contentView.bounds.width - padding * 2,
+      height: .greatestFiniteMagnitude
+    ))
+    codeLabel.frame = CGRect(
+      x: padding,
       y: 12,
-      width: view.bounds.width - 64,
-      height: 22
-    )
-    containerView.addSubview(titleLabel)
-
-    let descLabel = UILabel()
-    descLabel.text = description
-    descLabel.font = .preferredFont(forTextStyle: .caption1)
-    descLabel.textColor = .secondaryLabel
-    descLabel.frame = CGRect(
-      x: 16,
-      y: 32,
-      width: view.bounds.width - 64,
-      height: 16
-    )
-    containerView.addSubview(descLabel)
-
-    let contentHeight = content(containerView)
-
-    containerView.frame = CGRect(
-      x: 20,
-      y: yOffset,
-      width: view.bounds.width - 40,
-      height: contentHeight
+      width: contentView.bounds.width - padding * 2,
+      height: labelSize.height
     )
 
-    scrollView.addSubview(containerView)
+    // Layout container view
+    let containerY = codeLabel.frame.maxY + spacing
+    if let exampleView = exampleView {
+      containerView.frame = CGRect(
+        x: padding,
+        y: containerY,
+        width: exampleView.frame.width,
+        height: exampleView.frame.height
+      )
+      exampleView.frame = containerView.bounds
+    } else {
+      containerView.frame = CGRect(
+        x: padding,
+        y: containerY,
+        width: 100,
+        height: 44
+      )
+    }
+  }
 
-    return yOffset + contentHeight + 15
+  override func sizeThatFits(_ size: CGSize) -> CGSize {
+    let padding: CGFloat = 16
+    let spacing: CGFloat = 8
+
+    let labelSize = codeLabel.sizeThatFits(CGSize(
+      width: size.width - padding * 2,
+      height: .greatestFiniteMagnitude
+    ))
+    let exampleHeight = exampleView?.frame.height ?? 44
+
+    let totalHeight = 12 + labelSize.height + spacing + exampleHeight + 12
+    return CGSize(width: size.width, height: totalHeight)
+  }
+
+  func configure(with example: UIKitExample) {
+    codeLabel.text = example.code
+
+    // Remove old views
+    exampleView?.removeFromSuperview()
+
+    // Add new view
+    let view = example.createView()
+    containerView.addSubview(view)
+    exampleView = view
+
+    setNeedsLayout()
   }
 }
 

--- a/CGGenDemo/CLAUDE.md
+++ b/CGGenDemo/CLAUDE.md
@@ -1,50 +1,54 @@
-# CLAUDE.md - CGGenDemo Workflow
+# CGGenDemo Workflow
 
-This file documents the workflow for working with the CGGenDemo app.
+This document helps Claude Code work with the CGGenDemo app effectively.
+
+## Overview
+
+CGGenDemo is a demonstration app showcasing cggen's drawing APIs across SwiftUI, AppKit, and a playground environment. The app accepts command-line arguments to launch directly into specific tabs.
+
+## Tabs
+
+- **SwiftUI/AppKit/UIKit tabs**: Show code examples of cggen API usage with live previews, organized by categories like image creation, sizing, and UI integration.
+- **Playground tab**: Interactive environment for testing different drawings with adjustable size, content mode, and scale settings.
 
 ## Command Line Arguments
 
-The app supports launching with specific tabs using ArgumentParser:
-
-```bash
-# Launch with SwiftUI tab
---tab swiftui
-
-# Launch with AppKit tab  
---tab appkit
-
-# Launch with Playground tab
---tab playground
-```
+- `--tab [swiftui|appkit|playground]` - Launch with specific tab (default: swiftui)
 
 ## Building and Running
 
-### Build the app
-```bash
-xcodebuild -project CGGenDemo/CGGenDemo.xcodeproj -scheme CGGenDemo build
-```
+To build and run CGGenDemo, use these MCP tools in sequence:
 
-### Launch with specific tab
-```bash
-# Using Xcode MCP tool
-mcp__XcodeBuildMCP__launch_mac_app --appPath <path_to_app> --args ["--tab", "swiftui"]
-```
+1. **Build the app**
+   - Tool: `mcp__XcodeBuildMCP__build_mac_proj`
+   - projectPath: `/Users/alfred/dev/cggen/CGGenDemo/CGGenDemo.xcodeproj`
+   - scheme: `CGGenDemo`
+
+2. **Get the built app path**
+   - Tool: `mcp__XcodeBuildMCP__get_mac_app_path_proj`
+   - projectPath: `/Users/alfred/dev/cggen/CGGenDemo/CGGenDemo.xcodeproj`
+   - scheme: `CGGenDemo`
+
+3. **Launch the app**
+   - Tool: `mcp__XcodeBuildMCP__launch_mac_app`
+   - appPath: (path from step 2)
+   - args: (optional, e.g. `["--tab", "appkit"]`)
 
 ## Taking Screenshots
 
 ### Screenshot workflow
 1. Launch app with desired tab
-2. Use the macOS Shortcuts app to capture screenshots:
+2. Remove any existing screenshot file if present
+3. Capture screenshot immediately without sleep/delay:
 
 ```bash
-# Save screenshot to .claude_temp folder
 shortcuts run "cggendemo" --output-path .claude_temp/screenshot_name.png
 ```
 
 ### Screenshot storage
 - Screenshots are saved in `.claude_temp/` folder
 - This folder is gitignored to keep the repository clean
-- No need to clutter Desktop with temporary files
+- Always remove old screenshots before capturing new ones
 
 ### Shortcuts Setup
 - The `cggendemo.shortcut` file is included in this folder


### PR DESCRIPTION
## Summary

This PR refactors the CGGenDemo app to better showcase cggen API usage patterns across all Apple platforms.

## Changes

### API Documentation Focus
- Transformed SwiftUI, AppKit, and UIKit tabs from complex demo screens to clean API documentation
- Each tab now shows cggen usage examples with live previews
- Organized examples by categories (image creation, sizing, UI integration, etc.)

### Command Line Argument Fix
- Added `.allUnrecognized` parsing strategy to handle Xcode's extra arguments
- Prevents crashes when launched with unknown options

### UI Improvements
- Resized all SVG icons to uniform 40x40 dimensions (from various sizes)
- Made Playground tab more compact with better control layout
- Removed autolayout in UIKit implementation, using frame-based layout instead

### Documentation
- Updated CLAUDE.md with brief tab descriptions
- Added clear separation between API example tabs and interactive Playground

## Screenshots
The app now provides a consistent, educational interface for learning cggen APIs across all platforms.

🤖 Made with Claude Code