### PR TITLE
Refactor: Extract shape and filter primitive parsers to separate files

### DIFF
--- a/Sources/SVGParse/SVGAttributeGroupParser.swift
+++ b/Sources/SVGParse/SVGAttributeGroupParser.swift
@@ -104,11 +104,4 @@ enum SVGAttributeGroupParser {
       }
     }
   }
-
-  static func filterPrimitive<Data: Parser>(
-    _ data: Data
-  ) -> FilterPrimitive<Data>
-    where Data.Input == [String: String], Data.Output: Equatable {
-    FilterPrimitive(data)
-  }
 }

--- a/Sources/SVGParse/SVGFilterPrimitiveParser.swift
+++ b/Sources/SVGParse/SVGFilterPrimitiveParser.swift
@@ -1,0 +1,124 @@
+import Base
+@preconcurrency import Parsing
+
+enum SVGFilterPrimitiveParser {
+  typealias Attribute = SVGAttributeParser
+  typealias AttributeGroup = SVGAttributeGroupParser
+
+  private enum Tag: String {
+    case feBlend
+    case feColorMatrix
+    case feComponentTransfer
+    case feComposite
+    case feConvolveMatrix
+    case feDiffuseLighting
+    case feDisplacementMap
+    case feFlood
+    case feGaussianBlur
+    case feImage
+    case feMerge
+    case feMorphology
+    case feOffset
+    case feSpecularLighting
+    case feTile
+    case feTurbulence
+  }
+
+  struct FilterPrimitiveParser<T: Equatable>: Parser, Sendable {
+    typealias Input = XML
+    typealias Output = SVG.FilterPrimitiveElement<T>
+
+    let parser: AnyParser<Input, Output>
+
+    init(_ parser: some Parser<Input, Output>) {
+      self.parser = parser.eraseToAnyParser()
+    }
+
+    var body: AnyParser<Input, Output> {
+      parser
+    }
+  }
+
+  private static func element<Attributes>(
+    tag: Tag,
+    attributes: some Parser<[String: String], Attributes>
+  ) -> some Parser<XML, Attributes> {
+    let tagParser: some Parser<XML.Element, Void> =
+      tag.rawValue
+        .pullback(\.substring)
+        .pullback(\XML.Element.tag)
+
+    return OptionalInput(
+      tagParser ~>> (attributes <<~ End())
+        .pullback(\.attrs)
+    ).pullback(\XML.el)
+  }
+
+  private static func elementTagFeBlend<Attributes>(
+    _ attributes: some Parser<[String: String], Attributes>
+  ) -> some Parser<XML, Attributes> {
+    element(tag: .feBlend, attributes: attributes)
+  }
+
+  private static func elementTagFeColorMatrix<Attributes>(
+    _ attributes: some Parser<[String: String], Attributes>
+  ) -> some Parser<XML, Attributes> {
+    element(tag: .feColorMatrix, attributes: attributes)
+  }
+
+  private static func elementTagFeFlood<Attributes>(
+    _ attributes: some Parser<[String: String], Attributes>
+  ) -> some Parser<XML, Attributes> {
+    element(tag: .feFlood, attributes: attributes)
+  }
+
+  private static func elementTagFeGaussianBlur<Attributes>(
+    _ attributes: some Parser<[String: String], Attributes>
+  ) -> some Parser<XML, Attributes> {
+    element(tag: .feGaussianBlur, attributes: attributes)
+  }
+
+  private static func elementTagFeOffset<Attributes>(
+    _ attributes: some Parser<[String: String], Attributes>
+  ) -> some Parser<XML, Attributes> {
+    element(tag: .feOffset, attributes: attributes)
+  }
+
+  static let feBlend = FilterPrimitiveParser(
+    Parse(SVG.FilterPrimitiveFeBlend.init) {
+      Attribute.FilterPrimitiveIn(.in)
+      Attribute.FilterPrimitiveIn(.in2)
+      Attribute.BlendMode(.mode)
+    } |> AttributeGroup.FilterPrimitive.init >>> elementTagFeBlend
+  )
+
+  static let feColorMatrix = FilterPrimitiveParser(
+    Parse(SVG.FilterPrimitiveFeColorMatrix.init) {
+      Attribute.FilterPrimitiveIn(.in)
+      Attribute.FeColorMatrixType(.type)
+      Attribute.NumList(.values)
+    } |> AttributeGroup.FilterPrimitive.init >>> elementTagFeColorMatrix
+  )
+
+  static let feFlood = FilterPrimitiveParser(
+    Parse(SVG.FilterPrimitiveFeFlood.init) {
+      Attribute.Color(.floodColor)
+      Attribute.Num(.floodOpacity)
+    } |> AttributeGroup.FilterPrimitive.init >>> elementTagFeFlood
+  )
+
+  static let feGaussianBlur = FilterPrimitiveParser(
+    Parse(SVG.FilterPrimitiveFeGaussianBlur.init) {
+      Attribute.FilterPrimitiveIn(.in)
+      Attribute.NumberOptionalNumber(.stdDeviation)
+    } |> AttributeGroup.FilterPrimitive.init >>> elementTagFeGaussianBlur
+  )
+
+  static let feOffset = FilterPrimitiveParser(
+    Parse(SVG.FilterPrimitiveFeOffset.init) {
+      Attribute.FilterPrimitiveIn(.in)
+      Attribute.Num(.dx)
+      Attribute.Num(.dy)
+    } |> AttributeGroup.FilterPrimitive.init >>> elementTagFeOffset
+  )
+}

--- a/Sources/SVGParse/SVGShapeParser.swift
+++ b/Sources/SVGParse/SVGShapeParser.swift
@@ -1,0 +1,68 @@
+import Base
+@preconcurrency import Parsing
+
+enum SVGShapeParser {
+  typealias Attribute = SVGAttributeParser
+  typealias AttributeGroup = SVGAttributeGroupParser
+
+  struct ShapeParser<DataParser: Parser & Sendable>: Parser, Sendable
+    where DataParser.Input == [String: String],
+    DataParser.Output: Equatable & Sendable {
+    typealias Input = [String: String]
+    typealias Output = SVG.ShapeElement<DataParser.Output>
+
+    let dataParser: DataParser
+
+    init(_ dataParser: DataParser) {
+      self.dataParser = dataParser
+    }
+
+    var body: some Parser<Input, Output> {
+      Parse(SVG.ShapeElement.init) {
+        AttributeGroup.core
+        AttributeGroup.presentation
+        Attribute.Transform(.transform)
+        dataParser
+      }
+    }
+  }
+
+  static let rect = ShapeParser(
+    Parse(SVG.RectData.init) {
+      AttributeGroup.x
+      AttributeGroup.y
+      Attribute.Len(.rx)
+      Attribute.Len(.ry)
+      AttributeGroup.width
+      AttributeGroup.height
+    }
+  )
+
+  static let polygon = ShapeParser(
+    Attribute.ListOfPoints(.points).map(SVG.PolygonData.init)
+  )
+
+  static let circle = ShapeParser(
+    Parse(SVG.CircleData.init) {
+      Attribute.Coord(.cx)
+      Attribute.Coord(.cy)
+      Attribute.Coord(.r)
+    }
+  )
+
+  static let ellipse = ShapeParser(
+    Parse(SVG.EllipseData.init) {
+      Attribute.Coord(.cx)
+      Attribute.Coord(.cy)
+      Attribute.Len(.rx)
+      Attribute.Len(.ry)
+    }
+  )
+
+  static let path = ShapeParser(
+    Parse(SVG.PathData.init) {
+      Attribute.PathData(.d)
+      Attribute.Num(.pathLength)
+    }
+  )
+}


### PR DESCRIPTION
## Summary
- Extracted `ShapeParser` and `FilterPrimitiveParser` from `SVGParsing.swift` into their own dedicated files
- Improved code organization by separating parser logic into focused modules
- Reduced `SVGParsing.swift` from over 600 lines to 447 lines

## Changes
- Created `SVGShapeParser.swift` with generic `ShapeParser` that works without `AnyParser`
- Created `SVGFilterPrimitiveParser.swift` with `FilterPrimitiveParser` and related helper functions
- Removed redundant private static let aliases that were just forwarding to parsers
- Removed `func filterPrimitive` helper function in favor of direct init usage
- Updated all references to use parsers directly from their new modules

## Technical Details
- `ShapeParser` is now generic over `DataParser` with proper constraints
- `FilterPrimitiveParser` still uses `AnyParser` due to complex functional composition with `|>` and `>>>` operators
- All tests pass without modification

🤖 Made with Claude Code