### PR TITLE
Prepare for v1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to cggen will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2025-06-19
+
+### Added
+- Runtime SVG rendering support via `CGGenRuntime` module (#88)
+- Swift Package Manager plugin for automatic code generation (#59)
+- SwiftUI-friendly Drawing API with KeyPath syntax for Swift 6.1+ (#62)
+- Equatable and Hashable conformance for Drawing struct (#71)
+- Native quadratic Bezier curve support (#89)
+- Xcode project integration support (Beta) (#77)
+- SVG stroke-miterlimit attribute support (#69)
+- Comprehensive demo applications (Demo app and plugin-demo)
+- Path extraction API for animations and custom rendering
+- Content mode support for flexible scaling options
+- Cross-platform support (iOS, macOS, SwiftUI, UIKit, AppKit)
+
+### Changed
+- Refactored SVG parsers into separate focused modules (#81, #82)
+- Migrated to swift-parsing library for better parser composition (#80)
+- Renamed CGGenDemo to Demo for simplicity (#74)
+- Renamed plugin to cggen-spm-plugin for clarity (#72)
+- Optimized Drawing struct memory usage (#71)
+- Applied Swift 6 formatting and project cleanup (#78)
+- Improved code generation with better C bytecode formatting (#73)
+
+### Fixed
+- Sanitized target names for Swift identifiers (#76)
+- Fixed whitespace parser crash in Swift internals (#58)
+- Fixed demo app UI issues (#68)
+
+### Security
+- All generated code now uses compressed bytecode for smaller app bundles
+- No runtime file access required - all assets compiled at build time
+
+## [0.1.0] - Initial Release
+
+### Added
+- Basic SVG and PDF to Core Graphics code generation
+- Command-line interface
+- Support for common SVG elements and attributes
+- Objective-C code generation option

--- a/README.md
+++ b/README.md
@@ -229,7 +229,9 @@ cggen uses a sophisticated compilation approach:
 
 ## Documentation
 
+- [Architecture Overview](docs/architecture.md) - Detailed module structure and design
 - [API Usage Guide](docs/api-usage-guide.md) - Comprehensive examples and patterns
 - [API Design Considerations](docs/api-design-considerations.md) - Design decisions and alternatives
-- [Adding New Attributes](docs/adding_new_attribute.md) - Guide for contributing SVG attribute support
+- [Adding New Attributes](docs/adding-new-attribute.md) - Guide for contributing SVG attribute support
+- [Path Generation](docs/path-generation.md) - Path extraction for animations and custom rendering
 

--- a/Sources/cggen/main.swift
+++ b/Sources/cggen/main.swift
@@ -24,8 +24,8 @@ struct Main: ParsableCommand {
 
   static let configuration = CommandConfiguration(
     commandName: "cggen",
-    abstract: "Tool for generationg CoreGraphics code from vector images in pdf format",
-    version: "0.1"
+    abstract: "Tool for generating Core Graphics code from SVG and PDF files",
+    version: "1.0.0"
   )
 
   func run() throws {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,6 +31,12 @@
 
 This document describes the architecture and module structure of cggen, a tool for converting SVG and PDF files into optimized Core Graphics code.
 
+## Related Documentation
+- [API Usage Guide](api-usage-guide.md) - Practical examples for using cggen
+- [API Design Considerations](api-design-considerations.md) - Design decisions and rationale
+- [Adding New Attributes](adding-new-attribute.md) - Contributing SVG attribute support
+- [Path Generation](path-generation.md) - Path extraction feature architecture
+
 ## Overview
 
 cggen converts vector graphics (SVG/PDF) into either:

--- a/docs/adding-new-attribute.md
+++ b/docs/adding-new-attribute.md
@@ -2,6 +2,11 @@
 
 This document outlines the steps to add support for a new SVG attribute in the cggen project, using the implementation of `stroke-miterlimit` as an example.
 
+## Related Documentation
+- [Architecture Overview](architecture.md) - Understanding cggen's module structure
+- [API Usage Guide](api-usage-guide.md) - How the generated code is used
+- [Path Generation](path-generation.md) - Related path extraction features
+
 ## Overview
 
 When adding a new SVG attribute, you need to implement support across several components of the codebase:

--- a/docs/api-design-considerations.md
+++ b/docs/api-design-considerations.md
@@ -2,6 +2,11 @@
 
 This document outlines API approaches evaluated for making cggen-generated images seamlessly usable in SwiftUI and UIKit applications.
 
+## Related Documentation
+- [API Usage Guide](api-usage-guide.md) - Practical examples of the chosen API
+- [Architecture Overview](architecture.md) - How cggen implements these decisions
+- [Path Generation](path-generation.md) - Extended API for path extraction
+
 ## Goal
 
 Create a simple and ergonomic API that enables developers to integrate cggen-generated vector graphics similarly to system images, without manual support library imports.

--- a/docs/api-usage-guide.md
+++ b/docs/api-usage-guide.md
@@ -2,6 +2,11 @@
 
 This guide provides comprehensive examples and usage patterns for the cggen Drawing API.
 
+## Related Documentation
+- [Architecture Overview](architecture.md) - Understanding cggen's structure
+- [API Design Considerations](api-design-considerations.md) - Why the API works this way
+- [Path Generation](path-generation.md) - Extracting paths for custom rendering
+
 ## Basic Usage
 
 ### SwiftUI Views

--- a/docs/path-generation.md
+++ b/docs/path-generation.md
@@ -2,6 +2,12 @@
 
 This document explains cggen's path generation feature, which allows you to extract and reuse path definitions from SVG files as standalone Core Graphics path functions.
 
+## Related Documentation
+- [Architecture Overview](architecture.md) - How path generation fits in cggen
+- [API Usage Guide](api-usage-guide.md) - Using generated paths in your app
+- [API Design Considerations](api-design-considerations.md) - Design decisions for path APIs
+- [Adding New Attributes](adding-new-attribute.md) - Extending path support
+
 ## Overview
 
 The path generation feature enables you to:


### PR DESCRIPTION
## Summary
This PR prepares cggen for the v1.0.0 release by updating documentation, version numbers, and adding a comprehensive changelog.

## Changes
- Add CHANGELOG.md documenting all changes since 0.1.0
- Update version to 1.0.0 in main.swift
- Standardize documentation file naming (use dashes instead of underscores)
- Add cross-references between documentation files
- Update CLAUDE.md with better organization and quick reference
- Fix module name references in architecture docs
- Update CLI description to mention both SVG and PDF support

## Release Notes Preview
Major features in v1.0.0:
- Runtime SVG rendering support via `CGGenRuntime` module
- Swift Package Manager plugin for automatic code generation
- SwiftUI-friendly Drawing API with KeyPath syntax for Swift 6.1+
- Equatable and Hashable conformance for Drawing struct
- Native quadratic Bezier curve support
- Xcode project integration support (Beta)
- SVG stroke-miterlimit attribute support
- Comprehensive demo applications

## Next Steps
After merging:
1. Create git tag v1.0.0
2. Create GitHub release with the CHANGELOG content

🤖 Generated with [Claude Code](https://claude.ai/code)