### PR TITLE
Fix WebKit snapshot workflow to record failed snapshots

### DIFF
--- a/.github/workflows/update-webkit-snapshots.yml
+++ b/.github/workflows/update-webkit-snapshots.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Update snapshots
       run: |
         swift build
-        CGGEN_EXTENDED_TESTS=1 swift test --filter "SVGTest/testWebKit" || true
+        CGGEN_EXTENDED_TESTS=1 SNAPSHOT_TESTING_RECORD=failed swift test --filter "SVGTest/testWebKit" || true
         SNAPSHOT_TESTING_RECORD=failed swift test --parallel || true
     
     - name: Create PR


### PR DESCRIPTION
The WebKit snapshot update workflow was failing but not recording new snapshots.

This PR adds `SNAPSHOT_TESTING_RECORD=failed` to the WebKit test command so it will actually record new snapshots when there are differences.

🤖 Generated with [Claude Code](https://claude.ai/code)