### PR TITLE
Enable swift-syntax prebuilts in CI workflows

### DIFF
--- a/.github/workflows/nightly-extended-tests.yml
+++ b/.github/workflows/nightly-extended-tests.yml
@@ -47,7 +47,7 @@ jobs:
         xcode-version: latest-stable
     
     - name: Build
-      run: swift build
+      run: swift build --enable-experimental-prebuilts
     
     - name: Run gradient determinism test multiple times
       run: |

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -17,8 +17,10 @@ jobs:
       uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - name: Enable Xcode prebuilts
+      run: defaults write com.apple.dt.Xcode IDEPackageEnablePrebuilts YES
     - name: Build
-      run: swift build -v
+      run: swift build -v --enable-experimental-prebuilts
     - name: Run tests
       run: SWIFT_DETERMINISTIC_HASHING=1 swift test -v --parallel
     - name: Build Demo for macOS

--- a/.github/workflows/update-webkit-snapshots.yml
+++ b/.github/workflows/update-webkit-snapshots.yml
@@ -17,7 +17,7 @@ jobs:
     
     - name: Update snapshots
       run: |
-        swift build
+        swift build --enable-experimental-prebuilts
         CGGEN_EXTENDED_TESTS=1 SNAPSHOT_TESTING_RECORD=failed swift test || true
     
     - name: Create PR


### PR DESCRIPTION
This PR enables the experimental swift-syntax prebuilts feature in our CI workflows to improve build times.

## Changes
- Add `--enable-experimental-prebuilts` flag to `swift build` commands in all workflows
- Enable Xcode prebuilts via `defaults write com.apple.dt.Xcode IDEPackageEnablePrebuilts YES`

## Benefits
- ~40-50% faster CI builds by downloading prebuilt swift-syntax instead of compiling from source
- Prebuilts are built in release mode, so macros also run faster
- Available for swift-syntax 600.0.1 and 601.0.1 (we use 601.0.1)

## Reference
Based on the announcement: https://forums.swift.org/t/preview-swift-syntax-prebuilts-for-macros/80202