### PR TITLE
Simplify PlatformImageSupport API by removing KeyPath indirection

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -88,7 +88,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1630;
-				LastUpgradeCheck = 1630;
+				LastUpgradeCheck = 1640;
 				TargetAttributes = {
 					BBADE7712DF43C9D00179730 = {
 						CreatedOnToolsVersion = 16.3;
@@ -180,6 +180,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -204,6 +205,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -212,7 +214,6 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
-				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_MODULES = YES;
@@ -241,6 +242,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -257,6 +259,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
 		};
@@ -268,6 +271,7 @@
 				CODE_SIGN_ENTITLEMENTS = Demo/Demo.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -291,7 +295,6 @@
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
 				XROS_DEPLOYMENT_TARGET = 2.4;
 			};
@@ -305,6 +308,7 @@
 				CODE_SIGN_ENTITLEMENTS = Demo/Demo.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -328,7 +332,6 @@
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
 				XROS_DEPLOYMENT_TARGET = 2.4;
 			};

--- a/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,51 @@
+{
+  "originHash" : "b007b967b3a5b71ea17963ef3e3a32d5b21f47cecfd6d52b999336029480419d",
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "309a47b2b1d9b5e991f36961c983ecec72275be3",
+        "version" : "1.6.1"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "9810c8d6c2914de251e072312f01d3bf80071852",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-parsing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-parsing",
+      "state" : {
+        "revision" : "3432cb81164dd3d69a75d0d63205be5fbae2c34b",
+        "version" : "0.14.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "b2ed9eabefe56202ee4939dd9fc46b6241c88317",
+        "version" : "1.6.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Demo/Demo.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
+++ b/Demo/Demo.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1630"
+   LastUpgradeVersion = "1640"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Demo/Demo/AppKitDemo.swift
+++ b/Demo/Demo/AppKitDemo.swift
@@ -20,10 +20,10 @@ class AppKitDemoViewController: NSViewController, NSTableViewDataSource,
     // NSImage Creation
     Example(
       category: "NSImage Creation",
-      code: "NSImage.draw(\\.star)",
+      code: "NSImage.draw(.star)",
       createView: {
         let imageView = NSImageView()
-        imageView.image = NSImage.draw(\.star)
+        imageView.image = NSImage.draw(.star)
         imageView.imageScaling = .scaleProportionallyUpOrDown
         return imageView
       }
@@ -42,21 +42,21 @@ class AppKitDemoViewController: NSViewController, NSTableViewDataSource,
     // Sizing
     Example(
       category: "Sizing",
-      code: "NSImage.draw(\\.gear, scale: 2.0)",
+      code: "NSImage.draw(.gear, scale: 2.0)",
       createView: {
         let imageView = NSImageView()
-        imageView.image = NSImage.draw(\.gear, scale: 2.0)
+        imageView.image = NSImage.draw(.gear, scale: 2.0)
         imageView.imageScaling = .scaleProportionallyUpOrDown
         return imageView
       }
     ),
     Example(
       category: "Sizing",
-      code: ".draw(\\.mountain, size: CGSize(40, 30), contentMode: .aspectFit)",
+      code: ".draw(.mountain, size: CGSize(40, 30), contentMode: .aspectFit)",
       createView: {
         let imageView = NSImageView()
         imageView.image = NSImage.draw(
-          \.mountain,
+          .mountain,
           size: CGSize(width: 40, height: 30),
           contentMode: .aspectFit
         )
@@ -98,10 +98,10 @@ class AppKitDemoViewController: NSViewController, NSTableViewDataSource,
     // Interactive
     Example(
       category: "Interactive",
-      code: "NSButton(image: NSImage.draw(\\.gear))",
+      code: "NSButton(image: NSImage.draw(.gear))",
       createView: {
         let button = NSButton(
-          image: NSImage.draw(\.gear),
+          image: NSImage.draw(.gear),
           target: nil,
           action: nil
         )
@@ -111,11 +111,11 @@ class AppKitDemoViewController: NSViewController, NSTableViewDataSource,
     ),
     Example(
       category: "Interactive",
-      code: "button.image = NSImage.draw(\\.heart)",
+      code: "button.image = NSImage.draw(.heart)",
       createView: {
         let button = NSButton(
           title: "Like",
-          image: NSImage.draw(\.heart),
+          image: NSImage.draw(.heart),
           target: nil,
           action: nil
         )

--- a/Demo/Demo/UIKitDemo.swift
+++ b/Demo/Demo/UIKitDemo.swift
@@ -27,9 +27,9 @@ class UIKitDemoViewController: UIViewController {
         category: "UIImage Creation",
         items: [
           UIKitExample(
-            code: "UIImage.draw(\\.star)",
+            code: "UIImage.draw(.star)",
             createView: {
-              let imageView = UIImageView(image: UIImage.draw(\.star))
+              let imageView = UIImageView(image: UIImage.draw(.star))
               imageView.contentMode = .scaleAspectFit
               imageView.frame = CGRect(x: 0, y: 0, width: 30, height: 30)
               return imageView
@@ -45,12 +45,11 @@ class UIKitDemoViewController: UIViewController {
             }
           ),
           UIKitExample(
-            code: "UIImage.draw(\\.rocket, scale: 3.0)",
+            code: "UIImage.draw(.rocket, scale: 3.0)",
             createView: {
-              let imageView = UIImageView(image: UIImage.draw(
-                \.rocket,
-                scale: 3.0
-              ))
+              let imageView = UIImageView(
+                image: UIImage.draw(.rocket, scale: 3.0)
+              )
               imageView.contentMode = .scaleAspectFit
               imageView.frame = CGRect(x: 0, y: 0, width: 30, height: 30)
               return imageView
@@ -62,11 +61,11 @@ class UIKitDemoViewController: UIViewController {
         category: "Sizing",
         items: [
           UIKitExample(
-            code: "UIImage.draw(\\.mountain,\n  size: CGSize(width: 60, height: 40),\n  contentMode: .aspectFit)",
+            code: "UIImage.draw(.mountain,\n  size: CGSize(width: 60, height: 40),\n  contentMode: .aspectFit)",
             createView: {
               let imageView = UIImageView(
                 image: UIImage.draw(
-                  \.mountain,
+                  .mountain,
                   size: CGSize(width: 60, height: 40),
                   contentMode: .aspectFit
                 )
@@ -80,11 +79,11 @@ class UIKitDemoViewController: UIViewController {
             }
           ),
           UIKitExample(
-            code: "UIImage.draw(\\.mountain,\n  size: CGSize(width: 60, height: 40),\n  contentMode: .aspectFill)",
+            code: "UIImage.draw(.mountain,\n  size: CGSize(width: 60, height: 40),\n  contentMode: .aspectFill)",
             createView: {
               let imageView = UIImageView(
                 image: UIImage.draw(
-                  \.mountain,
+                  .mountain,
                   size: CGSize(width: 60, height: 40),
                   contentMode: .aspectFill
                 )
@@ -103,20 +102,20 @@ class UIKitDemoViewController: UIViewController {
         category: "UIButton Integration",
         items: [
           UIKitExample(
-            code: "button.setImage(UIImage.draw(\\.gear), for: .normal)",
+            code: "button.setImage(UIImage.draw(.gear), for: .normal)",
             createView: {
               let button = UIButton(type: .system)
-              button.setImage(UIImage.draw(\.gear), for: .normal)
+              button.setImage(UIImage.draw(.gear), for: .normal)
               button.setTitle(" Settings", for: .normal)
               button.frame = CGRect(x: 0, y: 0, width: 100, height: 44)
               return button
             }
           ),
           UIKitExample(
-            code: "// Tinted button\nbutton.setImage(UIImage.draw(\\.heart), for: .normal)\nbutton.tintColor = .systemRed",
+            code: "// Tinted button\nbutton.setImage(UIImage.draw(.heart), for: .normal)\nbutton.tintColor = .systemRed",
             createView: {
               let button = UIButton(type: .system)
-              button.setImage(UIImage.draw(\.heart), for: .normal)
+              button.setImage(UIImage.draw(.heart), for: .normal)
               button.tintColor = .systemRed
               button.frame = CGRect(x: 0, y: 0, width: 44, height: 44)
               return button

--- a/Sources/CGGenRTSupport/PlatformImageSupport+Deprecated.swift
+++ b/Sources/CGGenRTSupport/PlatformImageSupport+Deprecated.swift
@@ -1,0 +1,77 @@
+import CoreGraphics
+import SwiftUI
+
+// MARK: - Deprecated KeyPath API
+
+extension CGGenPlatformImage {
+  @MainActor
+  @inlinable
+  @available(*, deprecated, renamed: "draw(_:)")
+  public static func draw(_ keyPath: KeyPath<Drawing.Type, Drawing>)
+    -> CGGenPlatformImage {
+    CGGenPlatformImage(
+      drawing: Drawing.self[keyPath: keyPath],
+      scale: defaultScale
+    )
+  }
+
+  @MainActor
+  @inlinable
+  @available(*, deprecated, renamed: "draw(_:size:contentMode:)")
+  public static func draw(
+    _ keyPath: KeyPath<Drawing.Type, Drawing>,
+    size: CGSize,
+    contentMode: DrawingContentMode = .aspectFit
+  ) -> CGGenPlatformImage {
+    CGGenPlatformImage(
+      drawing: Drawing.self[keyPath: keyPath],
+      size: size,
+      contentMode: contentMode,
+      scale: defaultScale
+    )
+  }
+
+  @inlinable
+  @available(*, deprecated, renamed: "draw(_:scale:)")
+  public static func draw(
+    _ keyPath: KeyPath<Drawing.Type, Drawing>,
+    scale: CGFloat
+  ) -> CGGenPlatformImage {
+    CGGenPlatformImage(drawing: Drawing.self[keyPath: keyPath], scale: scale)
+  }
+
+  @inlinable
+  @available(*, deprecated, renamed: "draw(_:size:contentMode:scale:)")
+  public static func draw(
+    _ keyPath: KeyPath<Drawing.Type, Drawing>,
+    size: CGSize,
+    contentMode: DrawingContentMode = .aspectFit,
+    scale: CGFloat
+  ) -> CGGenPlatformImage {
+    CGGenPlatformImage(
+      drawing: Drawing.self[keyPath: keyPath],
+      size: size,
+      contentMode: contentMode,
+      scale: scale
+    )
+  }
+}
+
+extension Image {
+  @MainActor
+  @inlinable
+  @available(*, deprecated, renamed: "draw(_:)")
+  public static func draw(_ keyPath: KeyPath<Drawing.Type, Drawing>) -> Self {
+    Self(drawing: Drawing.self[keyPath: keyPath], scale: defaultScale)
+  }
+
+  @inlinable
+  @available(*, deprecated, renamed: "draw(_:scale:)")
+  public static func draw(
+    _ keyPath: KeyPath<Drawing.Type, Drawing>,
+    scale: CGFloat
+  ) -> Image {
+    Image(drawing: Drawing.self[keyPath: keyPath], scale: scale)
+  }
+}
+

--- a/Sources/CGGenRTSupport/PlatformImageSupport.swift
+++ b/Sources/CGGenRTSupport/PlatformImageSupport.swift
@@ -7,8 +7,6 @@ import SwiftUI
 public typealias CGGenPlatformImage = __CGGenPlatformImage
 
 extension CGGenPlatformImage {
-  // MARK: @MainActor methods using default scale
-
   @MainActor
   public convenience init(drawing: Drawing) {
     self.init(drawing: drawing, scale: defaultScale)
@@ -28,50 +26,42 @@ extension CGGenPlatformImage {
     )
   }
 
+  // MARK: Static Factory Methods
+
   @MainActor
-  @inlinable
-  public static func draw(_ keyPath: KeyPath<Drawing.Type, Drawing>)
-    -> CGGenPlatformImage {
-    CGGenPlatformImage(
-      drawing: Drawing.self[keyPath: keyPath],
-      scale: defaultScale
-    )
+  public static func draw(_ drawing: Drawing) -> CGGenPlatformImage {
+    CGGenPlatformImage(drawing: drawing, scale: defaultScale)
   }
 
   @MainActor
-  @inlinable
   public static func draw(
-    _ keyPath: KeyPath<Drawing.Type, Drawing>,
+    _ drawing: Drawing,
     size: CGSize,
     contentMode: DrawingContentMode = .aspectFit
   ) -> CGGenPlatformImage {
     CGGenPlatformImage(
-      drawing: Drawing.self[keyPath: keyPath],
+      drawing: drawing,
       size: size,
       contentMode: contentMode,
       scale: defaultScale
     )
   }
 
-  // MARK: Methods with explicit scale
-
-  @inlinable
   public static func draw(
-    _ keyPath: KeyPath<Drawing.Type, Drawing>,
+    _ drawing: Drawing,
     scale: CGFloat
   ) -> CGGenPlatformImage {
-    CGGenPlatformImage(drawing: Drawing.self[keyPath: keyPath], scale: scale)
+    CGGenPlatformImage(drawing: drawing, scale: scale)
   }
 
-  @inlinable
   public static func draw(
-    _ keyPath: KeyPath<Drawing.Type, Drawing>,
+    _ drawing: Drawing,
     size: CGSize,
     contentMode: DrawingContentMode = .aspectFit,
     scale: CGFloat
   ) -> CGGenPlatformImage {
     CGGenPlatformImage(
-      drawing: Drawing.self[keyPath: keyPath],
+      drawing: drawing,
       size: size,
       contentMode: contentMode,
       scale: scale
@@ -85,23 +75,20 @@ extension Image {
     self.init(drawing: drawing, scale: defaultScale)
   }
 
-  @MainActor
-  @inlinable
-  public static func draw(_ keyPath: KeyPath<Drawing.Type, Drawing>) -> Self {
-    Self(drawing: Drawing.self[keyPath: keyPath], scale: defaultScale)
-  }
-
   public init(drawing: Drawing, scale: CGFloat) {
     let image = CGGenPlatformImage(drawing: drawing, scale: scale)
     self.init(platformImage: image)
   }
 
-  @inlinable
-  public static func draw(
-    _ keyPath: KeyPath<Drawing.Type, Drawing>,
-    scale: CGFloat
-  ) -> Image {
-    Image(drawing: Drawing.self[keyPath: keyPath], scale: scale)
+  // MARK: Static Factory Methods
+
+  @MainActor
+  public static func draw(_ drawing: Drawing) -> Image {
+    Image(drawing: drawing, scale: defaultScale)
+  }
+
+  public static func draw(_ drawing: Drawing, scale: CGFloat) -> Image {
+    Image(drawing: drawing, scale: scale)
   }
 }
 

--- a/docs/api-design-considerations.md
+++ b/docs/api-design-considerations.md
@@ -182,13 +182,10 @@ struct ContentView: View {
 
 ## Final Decision
 
-A hybrid approach combining **Drawing namespace (#4)** and **KeyPath-based methods (#3)**:
+**Drawing namespace approach (#4)** with direct initializers:
 
 * **SwiftUI Views:** Direct usage as views (`Drawing.circle`).
-* **UIKit/AppKit Images:**
-
-  * Preferred: KeyPath-based (`UIImage.draw(\.circle)`).
-  * Alternative: Direct initializer (`UIImage(drawing: .circle)`).
+* **UIKit/AppKit Images:** Direct initializer (`UIImage(drawing: .circle)`).
 * **Core Graphics:** Direct drawing (`Drawing.circle.draw(context)`).
 
-This approach provides a clean, consistent API across platforms, offering optimal ergonomics for all scenarios.
+The KeyPath-based API was initially included but has been deprecated as it adds unnecessary complexity without providing real benefits. The direct initializer approach is simpler and more intuitive.

--- a/docs/api-usage-guide.md
+++ b/docs/api-usage-guide.md
@@ -19,18 +19,7 @@ Drawing.star
 
 ### UIKit/AppKit Images
 
-#### Preferred KeyPath Syntax (Swift 6.1+)
-```swift
-// UIKit
-let circleImage = UIImage.draw(\.circle)
-let starImage = UIImage.draw(\.star, scale: 2.0)
-
-// AppKit
-let circleImage = NSImage.draw(\.circle)
-let starImage = NSImage.draw(\.star, scale: 2.0)
-```
-
-#### Direct Initializers
+#### Using Initializers
 ```swift
 // UIKit
 let circleImage = UIImage(drawing: .circle)
@@ -39,6 +28,17 @@ let starImage = UIImage(drawing: .star, scale: 2.0)
 // AppKit
 let circleImage = NSImage(drawing: .circle)
 let starImage = NSImage(drawing: .star, scale: 2.0)
+```
+
+#### Using Static Factory Methods
+```swift
+// UIKit
+let circleImage = UIImage.draw(.circle)
+let starImage = UIImage.draw(.star, scale: 2.0)
+
+// AppKit
+let circleImage = NSImage.draw(.circle)
+let starImage = NSImage.draw(.star, scale: 2.0)
 ```
 
 ## Content Mode Support
@@ -61,16 +61,16 @@ public enum DrawingContentMode {
 ### Creating Images with Content Modes
 
 ```swift
-// Create thumbnail with aspect fit
+// Create thumbnail with aspect fit (using initializer)
 let thumbnail = UIImage(
   drawing: .logo,
   size: CGSize(width: 100, height: 100),
   contentMode: .aspectFit
 )
 
-// Create banner with aspect fill
+// Create banner with aspect fill (using static method)
 let banner = UIImage.draw(
-  \.banner,
+  .banner,
   size: CGSize(width: 320, height: 80),
   contentMode: .aspectFill
 )


### PR DESCRIPTION
## Summary
- Removed overengineered KeyPath-based API that provided no real value
- Kept simple direct initializers as primary API  
- Added static factory methods as convenient alternatives
- Moved deprecated API to separate file with proper migration warnings

## Motivation
The KeyPath approach added unnecessary complexity without benefits. The new API is cleaner, more intuitive, and follows Swift conventions.

## Changes
- Simplified PlatformImageSupport.swift to use direct Drawing arguments
- Created PlatformImageSupport+Deprecated.swift with deprecated KeyPath methods
- Updated documentation to reflect the new API patterns
- Updated Demo app to use the new API

## Migration
The old KeyPath API is deprecated with clear migration messages pointing to the new methods. Existing code will continue to work but will show deprecation warnings.

## Test plan
- [x] All tests pass
- [x] Demo app builds and runs correctly
- [x] API documentation updated