### PR TITLE
Fix iOS 13 compatibility by removing unused UTType code

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -27,3 +27,5 @@ jobs:
       run: xcodebuild -project Demo/Demo.xcodeproj -scheme Demo -configuration Release -destination 'platform=macOS' -skipMacroValidation build
     - name: Build Demo for iOS Simulator
       run: xcodebuild -project Demo/Demo.xcodeproj -scheme Demo -configuration Release -destination 'generic/platform=iOS Simulator' -skipMacroValidation build
+    - name: Build CGGenRuntime for iOS
+      run: xcodebuild -scheme CGGenRuntime -destination 'generic/platform=iOS' -skipMacroValidation build -quiet

--- a/Sources/CGGenCore/CoreGraphics.swift
+++ b/Sources/CGGenCore/CoreGraphics.swift
@@ -3,7 +3,6 @@ import CoreImage
 import CoreServices
 import ImageIO
 import simd
-import UniformTypeIdentifiers
 
 public typealias RGBAPixel = RGBAColor<UInt8>
 
@@ -286,23 +285,6 @@ extension CGImage {
       .createCGImage(final, from: rect)!
   }
 
-  public enum CGImageWriteError: Error {
-    case failedToCreateDestination
-    case failedDestinationFinalize
-  }
-
-  public func write(fileURL: CFURL) throws {
-    guard let destination = CGImageDestinationCreateWithURL(
-      fileURL,
-      UTType.png.identifier as CFString,
-      1,
-      nil
-    )
-    else { throw CGImageWriteError.failedDestinationFinalize }
-    CGImageDestinationAddImage(destination, self, nil)
-    guard CGImageDestinationFinalize(destination)
-    else { throw CGImageWriteError.failedDestinationFinalize }
-  }
 
   public func redraw(with background: CGColor) -> CGImage {
     let size = intSize


### PR DESCRIPTION
## Summary
- Removes unused `write(fileURL:)` method that used `UTType.png.identifier` (iOS 14+ only)
- Removes `UniformTypeIdentifiers` import as it's no longer needed
- Adds iOS build verification to CI to prevent future compatibility issues

## Problem
The package declares iOS 13 as minimum deployment target, but contained code using `UTType` which requires iOS 14+. This wasn't caught during development because `swift build` only compiles for the host platform (macOS).

## Solution
The `write(fileURL:)` method was never used anywhere in the codebase. Instead of adding complex availability checks for dead code, this PR simply removes it along with the unnecessary import.

## Testing
- ✅ All tests pass
- ✅ Builds successfully for macOS
- ✅ Builds successfully for iOS (verified with `xcodebuild -scheme CGGenRuntime -destination 'generic/platform=iOS'`)
- ✅ CI now includes iOS build verification to catch such issues early

Fixes #113