### PR TITLE
Add automated release workflow

### DIFF
--- a/.claude/commands/create-release.md
+++ b/.claude/commands/create-release.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(gh release view:*), Bash(gh release list:*)
+allowed-tools: Bash(gh release view:*), Bash(gh release list:*), Bash(gh release create:*), Bash(gh workflow run:*)
 description: Create a release
 ---
 
@@ -11,33 +11,52 @@ Create $ARGUMENTS release
 - Current git status: !`git status`
 - Current branch: !`git branch --show-current`
 
-**ENSURE YOU ARE ON MAIN BRANCH AND THERE ARE NO UNCOMMITTED CHANGES**
-**ENSURE MAIN BRANCH IS UP TO DATE WITH UPSTREAM REMOTE**
+**ENSURE THERE ARE NO UNCOMMITTED CHANGES**
+**ENSURE YOUR BRANCH IS UP TO DATE WITH UPSTREAM REMOTE**
 **ENSURE `HEAD` EXISTS ON UPSTREAM REMOTE**
 
 **IF ANY OF THESE CONDITIONS ARE NOT MET, EXIT NOW**
 
-- Validate version format (must be semantic versioning x.y.z)
-- Update version in all podspecs (Podspecs/*.podspec) to match the release version
-- Review 3-4 recent releases to understand the format and style:
-  - Use `gh release view` to check formatting conventions
-  - Note emoji usage, section organization, and tone
-- Find previous version of $ARGUMENTS
-- Checkout diff between previous and current version:
-  - If release is minor or patch, research the changes on the matter of breaking changes
-- Run tests and build to ensure release readiness:
-   - Run `swift test`
-   - Run `swift build --configuration release`
-- Create a temporary RELEASE_$ARGUMENTS.md file following the established format:
+## Process
+
+1. **Validate version format** (must be semantic versioning x.y.z)
+
+2. **Review recent releases** to understand the format and style:
+   - Use `gh release view` to check formatting conventions
+   - Note emoji usage, section organization, and tone
+
+3. **Analyze changes** since previous release:
+   - Find previous version
+   - Check diff between previous and current version
+   - If release is minor or patch, research breaking changes
+
+4. **Create release notes** in a temporary RELEASE_$ARGUMENTS.md file:
    - Match the style and formatting of recent releases
    - Include appropriate emoji headers (🚀, ✨, 🆕, etc.)
    - Organize sections consistently with previous releases
    - List changes with PR/commit references
 
-- **VERY IMPORTANT**: Ask user for confirmation with RELEASE_$ARGUMENTS.md content
-   - If user confirms, proceed to next steps
+5. **Ask user for confirmation** with RELEASE_$ARGUMENTS.md content
    - If user does not confirm, remove RELEASE_$ARGUMENTS.md and exit
 
-- Create git tag `$ARGUMENTS` with a brief summary message
-- Push the tag to the remote repository, ensure remote is an upstream, not a fork
-- Create github release with the content of RELEASE_$ARGUMENTS.md
+6. **Determine target branch**:
+   - Default: `main` for regular releases
+   - Ask user if releasing from a different branch (e.g., hotfix from `release-1.x`)
+
+7. **Create draft release**:
+   ```bash
+   gh release create $ARGUMENTS --draft --target <branch> --title "cggen $ARGUMENTS" --notes-file RELEASE_$ARGUMENTS.md --repo yandex/cggen
+   ```
+
+8. **Ask user** if they want to run the release workflow now
+
+9. **Run release workflow** (if user confirms):
+   ```bash
+   gh workflow run release.yml --repo yandex/cggen
+   ```
+   - Workflow will: update podspecs, run tests, create tag, publish release
+   - Link to monitor: https://github.com/yandex/cggen/actions/workflows/release.yml
+
+10. **Clean up**: Remove RELEASE_$ARGUMENTS.md
+
+**NOTE**: Do NOT manually update podspecs, create tags, or publish the release. The workflow handles all of this automatically.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,127 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: macos-15
+
+    steps:
+      - name: Find draft release
+        id: find-draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Get all releases via API (includes target_commitish)
+          releases=$(gh api repos/${{ github.repository }}/releases)
+
+          # Filter: draft=true, semver tag (x.y.z), no [WIP] in title
+          semver_drafts=$(echo "$releases" | jq '[.[] | select(.draft == true) | select(.tag_name | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) | select(.name | test("^\\[WIP\\]") | not)]')
+
+          count=$(echo "$semver_drafts" | jq 'length')
+
+          if [ "$count" -eq 0 ]; then
+            echo "❌ No draft release found with semver tag"
+            echo ""
+            echo "Create a draft release first with a tag like '1.2.0'"
+            exit 1
+          fi
+
+          if [ "$count" -gt 1 ]; then
+            echo "❌ Multiple draft releases found with semver tags:"
+            echo "$semver_drafts" | jq -r '.[].tag_name'
+            echo ""
+            echo "Mark other drafts with [WIP] prefix in title to exclude them"
+            exit 1
+          fi
+
+          # Extract release info
+          tag=$(echo "$semver_drafts" | jq -r '.[0].tag_name')
+          target=$(echo "$semver_drafts" | jq -r '.[0].target_commitish')
+
+          # Check if tag already exists via API
+          if gh api repos/${{ github.repository }}/git/refs/tags/$tag --silent 2>/dev/null; then
+            echo "❌ Tag $tag already exists"
+            echo ""
+            echo "Delete the existing tag or use a different version"
+            exit 1
+          fi
+
+          echo "✅ Found draft release: $tag (target: $target)"
+          echo "tag=$tag" >> $GITHUB_OUTPUT
+          echo "target=$target" >> $GITHUB_OUTPUT
+
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.find-draft.outputs.target }}
+          fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Update podspec versions
+        env:
+          VERSION: ${{ steps.find-draft.outputs.tag }}
+        run: |
+          echo "Updating podspecs to version $VERSION"
+
+          for podspec in Podspecs/*.podspec; do
+            # Use perl for reliable in-place replacement (works on both Linux and macOS)
+            perl -i -pe "s/s\.version\s*=\s*'[^']*'/s.version          = '$VERSION'/" "$podspec"
+            echo "Updated: $podspec"
+          done
+
+          # Show changes
+          git diff Podspecs/
+
+      - name: Enable Xcode prebuilts
+        run: defaults write com.apple.dt.Xcode IDEPackageEnablePrebuilts YES
+
+      - name: Run tests
+        run: SWIFT_DETERMINISTIC_HASHING=1 swift test --parallel --enable-experimental-prebuilts
+
+      - name: Build release
+        run: swift build --configuration release --enable-experimental-prebuilts
+
+      - name: Commit and push
+        env:
+          VERSION: ${{ steps.find-draft.outputs.tag }}
+          TARGET: ${{ steps.find-draft.outputs.target }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add Podspecs/*.podspec
+
+          if git diff --cached --quiet; then
+            echo "No changes to podspecs (versions already match)"
+          else
+            git commit -m "Update podspec versions to $VERSION"
+            git push origin "HEAD:$TARGET"
+          fi
+
+      - name: Create and push tag
+        env:
+          VERSION: ${{ steps.find-draft.outputs.tag }}
+        run: |
+          git tag "$VERSION"
+          git push origin "$VERSION"
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.find-draft.outputs.tag }}
+        run: |
+          gh release edit "$VERSION" --repo ${{ github.repository }} --draft=false
+          echo "✅ Published release $VERSION"
+          echo ""
+          echo "Release URL: https://github.com/${{ github.repository }}/releases/tag/$VERSION"


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for automated releases
- Update `/create-release` command to work with new workflow

## How it works

Run `/create-release 1.2.0` command, which:
1. Analyzes changes since previous release
2. Prepares release notes
3. Creates draft release via `gh release create --draft`
4. Runs workflow via `gh workflow run`

Workflow then:
1. Finds the draft release with semver tag
2. Updates podspec versions
3. Runs tests
4. Commits and pushes podspec changes
5. Creates tag
6. Publishes release

## Requirements
- `DEPLOY_KEY` secret (SSH deploy key with write access)
- Deploy key added to ruleset bypass list

## Test plan
- [ ] Create test draft release with version `99.0.0`
- [ ] Run workflow
- [ ] Verify podspecs updated, tag created, release published
- [ ] Clean up test release