### PR TITLE
@_cdecl functions in CGGenRTSupport should be public to avoid linker failures with Swift WMO

### DIFF
--- a/Sources/CGGenRTSupport/BytecodeRunner.swift
+++ b/Sources/CGGenRTSupport/BytecodeRunner.swift
@@ -50,7 +50,7 @@ public func runMergedBytecode(
 }
 
 @_cdecl("runMergedBytecode")
-func runMergedBytecode(
+public func runMergedBytecode(
   _ context: CGContext,
   _ start: UnsafePointer<UInt8>,
   _ decompressedLen: Int,
@@ -73,7 +73,7 @@ func runMergedBytecode(
 }
 
 @_cdecl("runBytecode")
-func runBytecode(
+public func runBytecode(
   _ context: CGContext,
   _ start: UnsafePointer<UInt8>,
   _ len: Int
@@ -86,7 +86,7 @@ func runBytecode(
 }
 
 @_cdecl("runPathBytecode")
-func runPathBytecode(
+public func runPathBytecode(
   _ path: CGMutablePath,
   _ start: UnsafePointer<UInt8>,
   _ len: Int
@@ -99,7 +99,7 @@ func runPathBytecode(
 }
 
 @_cdecl("runMergedPathBytecode")
-func runMergedPathBytecode(
+public func runMergedPathBytecode(
   _ path: CGMutablePath,
   _ compressedStart: UnsafePointer<UInt8>,
   _ decompressedSize: Int,

--- a/Sources/CGGenRTSupport/BytecodeRunner.swift
+++ b/Sources/CGGenRTSupport/BytecodeRunner.swift
@@ -50,6 +50,7 @@ public func runMergedBytecode(
 }
 
 @_cdecl("runMergedBytecode")
+@_spi(CGGenInternal)
 public func runMergedBytecode(
   _ context: CGContext,
   _ start: UnsafePointer<UInt8>,
@@ -73,6 +74,7 @@ public func runMergedBytecode(
 }
 
 @_cdecl("runBytecode")
+@_spi(CGGenInternal)
 public func runBytecode(
   _ context: CGContext,
   _ start: UnsafePointer<UInt8>,
@@ -86,6 +88,7 @@ public func runBytecode(
 }
 
 @_cdecl("runPathBytecode")
+@_spi(CGGenInternal)
 public func runPathBytecode(
   _ path: CGMutablePath,
   _ start: UnsafePointer<UInt8>,
@@ -99,6 +102,7 @@ public func runPathBytecode(
 }
 
 @_cdecl("runMergedPathBytecode")
+@_spi(CGGenInternal)
 public func runMergedPathBytecode(
   _ path: CGMutablePath,
   _ compressedStart: UnsafePointer<UInt8>,


### PR DESCRIPTION
Problem
When CGGenRTSupport is compiled as part of an Xcode app target with Whole Module Optimization (WMO) enabled, the @_cdecl functions in BytecodeRunner.swift are internalized by the Swift compiler and become local symbols (t in nm output). This causes linker failures when other object files (generated by cggen itself — e.g. CameraKitResources.o) try to call these C entry points:

`Undefined symbols for architecture x86_64:
  "_runMergedBytecode", referenced from:
      _YXDrawCameraRollImageInContext in CameraKitResources.o
  "_runMergedPathBytecode", referenced from:
      _YXSmallBoldFillerPath in ViconPathResources.o
ld: symbol(s) not found for architecture x86_64`


Root cause
Swift WMO internalizes symbols with internal access level, including those decorated with @_cdecl. Without WMO (e.g. when the library is compiled standalone), @_cdecl internal functions are exported globally — which is why the issue is not visible in Debug builds or when using prebuilt binaries.

Fix

Add public to the four @_cdecl functions in Sources/CGGenRTSupport/BytecodeRunner.swift:


`@_cdecl("runMergedBytecode")
public func runMergedBytecode(...)

@_cdecl("runMergedPathBytecode")
public func runMergedPathBytecode(...)

@_cdecl("runBytecode")
public func runBytecode(...)

@_cdecl("runPathBytecode")
public func runPathBytecode(...)`

public prevents WMO from internalizing these symbols regardless of compilation mode.